### PR TITLE
__file: rework

### DIFF
--- a/type/__file/explorer/cksum
+++ b/type/__file/explorer/cksum
@@ -1,6 +1,7 @@
-#!/bin/sh
+#!/bin/sh -e
 #
 # 2011-2012 Nico Schottelius (nico-cdist at schottelius.org)
+# 2022 Dennis Camera (cdist at dtnr.ch)
 #
 # This file is part of cdist.
 #
@@ -17,20 +18,15 @@
 # You should have received a copy of the GNU General Public License
 # along with cdist. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Retrieve the md5sum of a file to be created, if it is already existing.
+# Retrieve the cksum of the file if it already exists.
 #
 
-destination="/$__object_id"
+destination="/${__object_id:?}"
+state_should=$(cat "${__object:?}/parameter/state")
 
-if test -e "$destination"
+if test -f "${destination}" -a "${state_should}" = 'present'
 then
-	if test -f "$destination"
-	then
-		cksum < "$destination"
-	else
-		echo "NO REGULAR FILE"
-	fi
-else
-	echo "NO FILE FOUND, NO CHECKSUM CALCULATED."
+	# only calculate cksum if --state present, because it is ignored for other
+	# --states
+	cksum <"${destination}"
 fi

--- a/type/__file/explorer/cksum
+++ b/type/__file/explorer/cksum
@@ -11,7 +11,7 @@
 #
 # cdist is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
@@ -23,12 +23,14 @@
 
 destination="/$__object_id"
 
-if [ -e "$destination" ]; then
-    if [ -f  "$destination" ]; then
-        cksum < "$destination"
-    else
-        echo "NO REGULAR FILE"
-    fi
+if test -e "$destination"
+then
+	if test -f "$destination"
+	then
+		cksum < "$destination"
+	else
+		echo "NO REGULAR FILE"
+	fi
 else
-    echo "NO FILE FOUND, NO CHECKSUM CALCULATED."
+	echo "NO FILE FOUND, NO CHECKSUM CALCULATED."
 fi

--- a/type/__file/explorer/stat
+++ b/type/__file/explorer/stat
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/sh -e
 #
 # 2013 Steven Armstrong (steven-cdist armstrong.cc)
 # 2019 Nico Schottelius (nico-cdist at schottelius.org)
-# 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2020,2022 Dennis Camera (cdist at dtnr.ch)
 #
 # This file is part of cdist.
 #
@@ -20,38 +20,32 @@
 # along with cdist. If not, see <http://www.gnu.org/licenses/>.
 #
 
-destination="/$__object_id"
+destination="/${__object_id:?}"
 
 fallback() {
 	# Fallback: Patch the output together, manually.
 
-	ls_line=$(ls -ldn "$destination")
-
-	uid=$(echo "$ls_line" | awk '{ print $3 }')
-	gid=$(echo "$ls_line" | awk '{ print $4 }')
+	read -r mode_text links uid gid size _ <<-EOF
+	$(ls -ldn "$destination")
+	EOF
 
 	owner=$(awk -F: -v uid="$uid" '$3 == uid { print $1; f=1 } END { if (!f) print "UNKNOWN" }' /etc/passwd)
 	group=$(awk -F: -v gid="$gid" '$3 == gid { print $1; f=1 } END { if (!f) print "UNKNOWN" }' /etc/group)
 
-	mode_text=$(echo "$ls_line" | awk '{ print $1 }')
-	mode=$(echo "$mode_text" | awk '{for(i=8;i>=0;--i){c=substr($1,10-i,1);k+=((c~/[rwxst]/)*2^i);if(!(i%3))k+=(tolower(c)~/[lst]/)*2^(9+i/3)}printf("%04o",k)}')
-
-	size=$(echo "$ls_line" | awk '{ print $5 }')
-	links=$(echo "$ls_line" | awk '{ print $2 }')
+	mode=$(echo "${mode_text}" | awk '{for(i=8;i>=0;--i){c=substr($1,10-i,1);k+=((c~/[rwxst]/)*2^i);if(!(i%3))k+=(tolower(c)~/[lst]/)*2^(9+i/3)}printf("%04o",k)}')
 
 	printf 'type: %s\nowner: %d %s\ngroup: %d %s\nmode: %s %s\nsize: %d\nlinks: %d\n' \
-		"$("$__type_explorer/type")" \
-		"$uid" "$owner" \
-		"$gid" "$group" \
-		"$mode" "$mode_text" \
-		"$size" \
-		"$links"
+		"$("${__type_explorer:?}/type")" \
+		"${uid}" "${owner}" \
+		"${gid}" "${group}" \
+		"${mode}" "${mode_text}" \
+		"${size}" \
+		"${links}"
 }
 
 
 # nothing to work with, nothing we could do
-[ -e "$destination" ] || exit 0
-
+test -e "${destination}" || exit 0
 
 command -v stat >/dev/null 2>&1 || {
 	fallback
@@ -59,9 +53,10 @@ command -v stat >/dev/null 2>&1 || {
 }
 
 
-case $("$__explorer/os")
+case $("${__explorer:?}/os")
 in
-	freebsd|netbsd|openbsd|macosx)
+	(freebsd|netbsd|openbsd|macosx)
+		# BSD
 		stat -f 'type: %HT
 owner: %Du %Su
 group: %Dg %Sg
@@ -70,7 +65,7 @@ size: %Dz
 links: %Dl
 ' "$destination" | awk '/^type/ { print tolower($0); next } { print }'
 		;;
-	*)
+	(*)
 		# NOTE: Do not use --printf here as it is not supported by BusyBox stat.
 		# NOTE: BusyBox's stat might not support the "-c" option, in which case
 		#		 we fall through to the shell fallback.
@@ -79,6 +74,6 @@ owner: %u %U
 group: %g %G
 mode: %04a %A
 size: %s
-links: %h' "$destination" 2>/dev/null || fallback
+links: %h' "${destination}" 2>/dev/null || fallback
 		;;
 esac

--- a/type/__file/explorer/stat
+++ b/type/__file/explorer/stat
@@ -23,29 +23,29 @@
 destination="/$__object_id"
 
 fallback() {
-   # Fallback: Patch the output together, manually.
+	# Fallback: Patch the output together, manually.
 
-   ls_line=$(ls -ldn "$destination")
+	ls_line=$(ls -ldn "$destination")
 
-   uid=$(echo "$ls_line" | awk '{ print $3 }')
-   gid=$(echo "$ls_line" | awk '{ print $4 }')
+	uid=$(echo "$ls_line" | awk '{ print $3 }')
+	gid=$(echo "$ls_line" | awk '{ print $4 }')
 
-   owner=$(awk -F: -v uid="$uid" '$3 == uid { print $1; f=1 } END { if (!f) print "UNKNOWN" }' /etc/passwd)
-   group=$(awk -F: -v gid="$gid" '$3 == gid { print $1; f=1 } END { if (!f) print "UNKNOWN" }' /etc/group)
+	owner=$(awk -F: -v uid="$uid" '$3 == uid { print $1; f=1 } END { if (!f) print "UNKNOWN" }' /etc/passwd)
+	group=$(awk -F: -v gid="$gid" '$3 == gid { print $1; f=1 } END { if (!f) print "UNKNOWN" }' /etc/group)
 
-   mode_text=$(echo "$ls_line" | awk '{ print $1 }')
-   mode=$(echo "$mode_text" | awk '{for(i=8;i>=0;--i){c=substr($1,10-i,1);k+=((c~/[rwxst]/)*2^i);if(!(i%3))k+=(tolower(c)~/[lst]/)*2^(9+i/3)}printf("%04o",k)}')
+	mode_text=$(echo "$ls_line" | awk '{ print $1 }')
+	mode=$(echo "$mode_text" | awk '{for(i=8;i>=0;--i){c=substr($1,10-i,1);k+=((c~/[rwxst]/)*2^i);if(!(i%3))k+=(tolower(c)~/[lst]/)*2^(9+i/3)}printf("%04o",k)}')
 
-   size=$(echo "$ls_line" | awk '{ print $5 }')
-   links=$(echo "$ls_line" | awk '{ print $2 }')
+	size=$(echo "$ls_line" | awk '{ print $5 }')
+	links=$(echo "$ls_line" | awk '{ print $2 }')
 
-   printf 'type: %s\nowner: %d %s\ngroup: %d %s\nmode: %s %s\nsize: %d\nlinks: %d\n' \
-      "$("$__type_explorer/type")" \
-      "$uid" "$owner" \
-      "$gid" "$group" \
-      "$mode" "$mode_text" \
-      "$size" \
-      "$links"
+	printf 'type: %s\nowner: %d %s\ngroup: %d %s\nmode: %s %s\nsize: %d\nlinks: %d\n' \
+		"$("$__type_explorer/type")" \
+		"$uid" "$owner" \
+		"$gid" "$group" \
+		"$mode" "$mode_text" \
+		"$size" \
+		"$links"
 }
 
 
@@ -54,31 +54,31 @@ fallback() {
 
 
 command -v stat >/dev/null 2>&1 || {
-   fallback
-   exit
+	fallback
+	exit
 }
 
 
 case $("$__explorer/os")
 in
-   freebsd|netbsd|openbsd|macosx)
-      stat -f 'type: %HT
+	freebsd|netbsd|openbsd|macosx)
+		stat -f 'type: %HT
 owner: %Du %Su
 group: %Dg %Sg
 mode: %Mp%03Lp %Sp
 size: %Dz
 links: %Dl
 ' "$destination" | awk '/^type/ { print tolower($0); next } { print }'
-      ;;
-   *)
-      # NOTE: Do not use --printf here as it is not supported by BusyBox stat.
-      # NOTE: BusyBox's stat might not support the "-c" option, in which case
-      #       we fall through to the shell fallback.
-      stat -c 'type: %F
+		;;
+	*)
+		# NOTE: Do not use --printf here as it is not supported by BusyBox stat.
+		# NOTE: BusyBox's stat might not support the "-c" option, in which case
+		#		 we fall through to the shell fallback.
+		stat -c 'type: %F
 owner: %u %U
 group: %g %G
 mode: %04a %A
 size: %s
 links: %h' "$destination" 2>/dev/null || fallback
-      ;;
+		;;
 esac

--- a/type/__file/explorer/type
+++ b/type/__file/explorer/type
@@ -1,6 +1,7 @@
-#!/bin/sh
+#!/bin/sh -e
 #
 # 2013 Steven Armstrong (steven-cdist armstrong.cc)
+# 2022 Dennis Camera (cdist at dtnr.ch)
 #
 # This file is part of cdist.
 #
@@ -18,18 +19,20 @@
 # along with cdist. If not, see <http://www.gnu.org/licenses/>.
 #
 
-destination="/$__object_id"
+destination="/${__object_id:?}"
 
-if test ! -e "$destination"
-then
-	echo none
-elif test -h "$destination"
+# NOTE: check for symlink first, because if the file the symlink points to is
+#       non-existent -h is true, but -e is false.
+if test -h "${destination}"
 then
 	echo symlink
-elif test -f "$destination"
+elif test ! -e "${destination}"
+then
+	echo none
+elif test -f "${destination}"
 then
 	echo file
-elif test -d "$destination"
+elif test -d "${destination}"
 then
 	echo directory
 else

--- a/type/__file/explorer/type
+++ b/type/__file/explorer/type
@@ -20,14 +20,18 @@
 
 destination="/$__object_id"
 
-if [ ! -e "$destination" ]; then
-   echo none
-elif [ -h "$destination" ]; then
-   echo symlink
-elif [ -f "$destination" ]; then
-   echo file
-elif [ -d "$destination" ]; then
-   echo directory
+if test ! -e "$destination"
+then
+	echo none
+elif test -h "$destination"
+then
+	echo symlink
+elif test -f "$destination"
+then
+	echo file
+elif test -d "$destination"
+then
+	echo directory
 else
-   echo unknown
+	echo unknown
 fi

--- a/type/__file/gencode-local
+++ b/type/__file/gencode-local
@@ -26,102 +26,102 @@ type="$(cat "$__object/explorer/type")"
 [ "$state_should" = "exists" ] && [ "$type" = "file" ] && exit 0 # nothing to do
 
 if [ "$state_should" = "pre-exists" ]; then
-   if [ -f "$__object/parameter/source" ]; then
-      echo "--source cannot be used with --state pre-exists" >&2
-      exit 1
-   fi
+	if [ -f "$__object/parameter/source" ]; then
+		echo "--source cannot be used with --state pre-exists" >&2
+		exit 1
+	fi
 
-   case $type in
-      file)
-         # nothing to do
-         exit 0
-      ;;
-      none)
-         printf 'File "%s" does not exist\n' "$destination" >&2
-         exit 1
-      ;;
-      directory|symlink)
-         printf 'File "%s" exists and is a %s, but should be a regular file\n' "$destination" "$type" >&2
-         exit 1
-      ;;
-      *)
-         printf 'File or directory "%s" is in an unknown state\n' "$destination" >&2
-         exit 1
-      ;;
-   esac
+	case $type in
+		file)
+			# nothing to do
+			exit 0
+			;;
+		none)
+			printf 'File "%s" does not exist\n' "$destination" >&2
+			exit 1
+			;;
+		directory|symlink)
+			printf 'File "%s" exists and is a %s, but should be a regular file\n' "$destination" "$type" >&2
+			exit 1
+			;;
+		*)
+			printf 'File or directory "%s" is in an unknown state\n' "$destination" >&2
+			exit 1
+			;;
+	esac
 fi
 
 upload_file=
 create_file=
 if [ "$state_should" = "present" ] || [ "$state_should" = "exists" ]; then
-   if [ ! -f "$__object/parameter/source" ]; then
-      remote_stat="$(cat "$__object/explorer/stat")"
-      if [ -z "$remote_stat" ]; then
-         create_file=1
-         echo create >> "$__messages_out"
-      fi
-   else
-      source="$(cat "$__object/parameter/source")"
-      if [ "$source" = "-" ]; then
-         source="$__object/stdin"
-      fi
-      if [ ! -f "$source" ]; then
-         echo "Source \"$source\" does not exist." >&2
-         exit 1
-      else
-         if [ "$type" != "file" ]; then
-            # destination is not a regular file, upload source to replace it
-            upload_file=1
-            echo upload >> "$__messages_out"
-         else
-            local_cksum="$(cksum < "$source")"
-            remote_cksum="$(cat "$__object/explorer/cksum")"
-            if [ "$local_cksum" != "$remote_cksum" ]; then
-               # destination is a regular file, but not the right one
-               upload_file=1
-            fi
-         fi
-      fi
-   fi
-   if [ "$create_file" ] || [ "$upload_file" ]; then
-      # tell gencode-remote that we created or uploaded a file and that it must
-      # set all attributes no matter what the explorer retreived
-      mkdir "$__object/files"
-      touch "$__object/files/set-attributes"
+	if [ ! -f "$__object/parameter/source" ]; then
+		remote_stat="$(cat "$__object/explorer/stat")"
+		if [ -z "$remote_stat" ]; then
+			create_file=1
+			echo create >> "$__messages_out"
+		fi
+	else
+		source="$(cat "$__object/parameter/source")"
+		if [ "$source" = "-" ]; then
+			source="$__object/stdin"
+		fi
+		if [ ! -f "$source" ]; then
+			echo "Source \"$source\" does not exist." >&2
+			exit 1
+		else
+			if [ "$type" != "file" ]; then
+				# destination is not a regular file, upload source to replace it
+				upload_file=1
+				echo upload >> "$__messages_out"
+			else
+				local_cksum="$(cksum < "$source")"
+				remote_cksum="$(cat "$__object/explorer/cksum")"
+				if [ "$local_cksum" != "$remote_cksum" ]; then
+					# destination is a regular file, but not the right one
+					upload_file=1
+				fi
+			fi
+		fi
+	fi
+	if [ "$create_file" ] || [ "$upload_file" ]; then
+		# tell gencode-remote that we created or uploaded a file and that it must
+		# set all attributes no matter what the explorer retreived
+		mkdir "$__object/files"
+		touch "$__object/files/set-attributes"
 
-      if [ "$create_file" ]; then
-         # When creating an empty file we create it locally and then
-         # upload it so that permissions can be set before moving the file
-         # into place.
-         source="$__object/files/empty"
-         touch "$source"
-      fi
+		if [ "$create_file" ]; then
+			# When creating an empty file we create it locally and then
+			# upload it so that permissions can be set before moving the file
+			# into place.
+			source="$__object/files/empty"
+			touch "$source"
+		fi
 
-      # upload file to temp location
-      upload_destination="$(mktemp -u "/__cdist${destination}.cdist.XXXXXXXXXX" | sed 's|^/__cdist||')"
-      # Yes, we are aware that this is a race condition.
-      # However:
-      # a) cdist usually writes to directories that are not user writable
-      #    (probably > 99.9%)
-      # b) if they are user owned, the user / attacker always wins
-      #    (probably < 0.1%)
-      # c) the only case which we could improve are tmp directories and we
-      #    don't think managing tmp directories with cdist is a typical case
-      #    ("the rest %)"
+		# upload file to temp location
+		upload_destination="$(mktemp -u "/__cdist${destination}.cdist.XXXXXXXXXX" | sed 's|^/__cdist||')"
+		# Yes, we are aware that this is a race condition.
+		# However:
+		# a) cdist usually writes to directories that are not user writable
+		#	 (probably > 99.9%)
+		# b) if they are user owned, the user / attacker always wins
+		#	 (probably < 0.1%)
+		# c) the only case which we could improve are tmp directories and we
+		#	 don't think managing tmp directories with cdist is a typical case
+		#	 ("the rest %)"
 
-      # Tell gencode-remote to where we uploaded the file so it can move
-      # it to its final destination.
-      echo "$upload_destination" > "$__object/files/upload-destination"
+		# Tell gencode-remote to where we uploaded the file so it can move
+		# it to its final destination.
+		echo "$upload_destination" > "$__object/files/upload-destination"
 
-      # IPv6 fix
-      if echo "${__target_host}" | grep -q -E '^[0-9a-fA-F:]+$'
-      then
-          my_target_host="[${__target_host}]"
-      else
-          my_target_host="${__target_host}"
-      fi
-      cat << DONE
+		# IPv6 fix
+		if echo "${__target_host}" | grep -q -E '^[0-9a-fA-F:]+$'
+		then
+			 my_target_host="[${__target_host}]"
+		else
+			 my_target_host="${__target_host}"
+		fi
+		cat << DONE
 $__remote_copy "$source" "${my_target_host}:${upload_destination}"
 DONE
-   fi
+	fi
 fi

--- a/type/__file/gencode-local
+++ b/type/__file/gencode-local
@@ -2,6 +2,7 @@
 #
 # 2011-2012 Nico Schottelius (nico-cdist at schottelius.org)
 # 2013-2022 Steven Armstrong (steven-cdist armstrong.cc)
+# 2022 Dennis Camera (cdist at dtnr.ch)
 #
 # This file is part of cdist.
 #
@@ -19,109 +20,122 @@
 # along with cdist. If not, see <http://www.gnu.org/licenses/>.
 #
 
-destination="/$__object_id"
-state_should="$(cat "$__object/parameter/state")"
-type="$(cat "$__object/explorer/type")"
+quote() { printf '%s\n' "$*" | sed "s/'/'\\\\''/g;1s/^/'/;\$s/\$/'/"; }
 
-[ "$state_should" = "exists" ] && [ "$type" = "file" ] && exit 0 # nothing to do
+destination="/${__object_id:?}"
+state_should=$(cat "${__object:?}/parameter/state")
+type_is=$(cat "${__object:?}/explorer/type")
 
-if [ "$state_should" = "pre-exists" ]; then
-	if [ -f "$__object/parameter/source" ]; then
-		echo "--source cannot be used with --state pre-exists" >&2
-		exit 1
-	fi
+upload_file() {
+	# source $1
+	# destination $2
 
-	case $type in
-		file)
-			# nothing to do
-			exit 0
-			;;
-		none)
-			printf 'File "%s" does not exist\n' "$destination" >&2
-			exit 1
-			;;
-		directory|symlink)
-			printf 'File "%s" exists and is a %s, but should be a regular file\n' "$destination" "$type" >&2
-			exit 1
-			;;
-		*)
-			printf 'File or directory "%s" is in an unknown state\n' "$destination" >&2
-			exit 1
-			;;
-	esac
-fi
+	# tell gencode-remote that we created or uploaded a file and that it
+	# must set all attributes no matter what the explorer retreived
+	mkdir "${__object:?}/files"
+	touch "${__object:?}/files/file-uploaded"
 
-upload_file=
-create_file=
-if [ "$state_should" = "present" ] || [ "$state_should" = "exists" ]; then
-	if [ ! -f "$__object/parameter/source" ]; then
-		remote_stat="$(cat "$__object/explorer/stat")"
-		if [ -z "$remote_stat" ]; then
-			create_file=1
-			echo create >> "$__messages_out"
-		fi
+	# upload file to temp location
+	_upload_destination=$(mktemp -u "/__cdist${2:?}.cdist.XXXXXX" | sed 's|^/__cdist||')
+	# Yes, we are aware that this is a race condition.
+	# However:
+	# a) cdist usually writes to directories that are not user writable
+	#	 (probably > 99.9%)
+	# b) if they are user owned, the user / attacker always wins
+	#	 (probably < 0.1%)
+	# c) the only case which we could improve are tmp directories and we
+	#	 don't think managing tmp directories with cdist is a typical case
+	#	 ("the rest %)"
+
+	# Tell gencode-remote to where we uploaded the file so it can move
+	# it to its final destination.
+	echo "${_upload_destination}" >"${__object:?}/files/upload-destination"
+
+	# IPv6 fix
+	if expr "${__target_host:?}" : '[0-9a-fA-F:]\{1,\}$' >/dev/null
+	then
+		_destination_host="[${__target_host:?}]"
 	else
-		source="$(cat "$__object/parameter/source")"
-		if [ "$source" = "-" ]; then
-			source="$__object/stdin"
-		fi
-		if [ ! -f "$source" ]; then
-			echo "Source \"$source\" does not exist." >&2
-			exit 1
-		else
-			if [ "$type" != "file" ]; then
-				# destination is not a regular file, upload source to replace it
-				upload_file=1
-				echo upload >> "$__messages_out"
-			else
-				local_cksum="$(cksum < "$source")"
-				remote_cksum="$(cat "$__object/explorer/cksum")"
-				if [ "$local_cksum" != "$remote_cksum" ]; then
-					# destination is a regular file, but not the right one
-					upload_file=1
-				fi
-			fi
-		fi
+		_destination_host=${__target_host:?}
 	fi
-	if [ "$create_file" ] || [ "$upload_file" ]; then
-		# tell gencode-remote that we created or uploaded a file and that it must
-		# set all attributes no matter what the explorer retreived
-		mkdir "$__object/files"
-		touch "$__object/files/set-attributes"
 
-		if [ "$create_file" ]; then
-			# When creating an empty file we create it locally and then
-			# upload it so that permissions can be set before moving the file
-			# into place.
-			source="$__object/files/empty"
-			touch "$source"
-		fi
+	cat <<-EOF
+	${__remote_copy:?} $(quote "${1:?}") $(quote "${_destination_host}"):$(quote "${_upload_destination}")
+	EOF
 
-		# upload file to temp location
-		upload_destination="$(mktemp -u "/__cdist${destination}.cdist.XXXXXXXXXX" | sed 's|^/__cdist||')"
-		# Yes, we are aware that this is a race condition.
-		# However:
-		# a) cdist usually writes to directories that are not user writable
-		#	 (probably > 99.9%)
-		# b) if they are user owned, the user / attacker always wins
-		#	 (probably < 0.1%)
-		# c) the only case which we could improve are tmp directories and we
-		#	 don't think managing tmp directories with cdist is a typical case
-		#	 ("the rest %)"
+	unset _destination_host _upload_destination
+}
 
-		# Tell gencode-remote to where we uploaded the file so it can move
-		# it to its final destination.
-		echo "$upload_destination" > "$__object/files/upload-destination"
-
-		# IPv6 fix
-		if echo "${__target_host}" | grep -q -E '^[0-9a-fA-F:]+$'
+case ${state_should}
+in
+	(pre-exists)
+		if test -f "${__object:?}/parameter/source"
 		then
-			 my_target_host="[${__target_host}]"
-		else
-			 my_target_host="${__target_host}"
+			echo '--source cannot be used with --state pre-exists' >&2
+			exit 1
 		fi
-		cat << DONE
-$__remote_copy "$source" "${my_target_host}:${upload_destination}"
-DONE
-	fi
-fi
+
+		case ${type_is}
+		in
+			(file)
+				# nothing to do
+				exit 0
+				;;
+			(none)
+				printf 'File "%s" does not exist\n' "${destination}" >&2
+				exit 1
+				;;
+			(directory|symlink)
+				printf 'File "%s" exists and is a %s, but should be a regular file\n' "${destination}" "${type_is}" >&2
+				exit 1
+				;;
+			(*)
+				printf 'File or directory "%s" is in an unknown state\n' "${destination}" >&2
+				exit 1
+				;;
+		esac
+		;;
+	(present|exists)
+		upload_file=false
+
+		if test "${type_is}" != 'file'
+		then
+			# destination is not a regular file
+			upload_file=true
+		elif test "${state_should}" = 'present' \
+		&& ! cksum <"${source}" | cmp -s "${__object:?}/explorer/cksum" -
+		then
+			# destination is a regular file, but not the right one
+			upload_file=true
+		fi
+
+		if ${upload_file?}
+		then
+			# determine source
+			if test -f "${__object:?}/parameter/source"
+			then
+				source=$(cat "${__object:?}/parameter/source")
+				if test "${source}" = '-'
+				then
+					source="${__object:?}/stdin"
+				fi
+
+				test -f "${source}" || {
+					printf 'Source "%s" does not exist.\n' "${source}" >&2
+					exit 1
+				}
+
+				echo upload >>"${__messages_out:?}"
+			else
+				# when creating an empty file we create it locally and then
+				# upload it so that permissions can be set before moving the file
+				# into place.
+				source=/dev/null
+
+				echo create >>"${__messages_out:?}"
+			fi
+
+			upload_file "${source}" "${destination}"
+		fi
+		;;
+esac

--- a/type/__file/gencode-remote
+++ b/type/__file/gencode-remote
@@ -2,6 +2,7 @@
 #
 # 2011-2013 Nico Schottelius (nico-cdist at schottelius.org)
 # 2013-2022 Steven Armstrong (steven-cdist armstrong.cc)
+# 2022 Dennis Camera (cdist at dtnr.ch)
 #
 # This file is part of cdist.
 #
@@ -19,106 +20,113 @@
 # along with cdist. If not, see <http://www.gnu.org/licenses/>.
 #
 
-destination="/$__object_id"
-state_should="$(cat "$__object/parameter/state")"
-type="$(cat "$__object/explorer/type")"
-stat_file="$__object/explorer/stat"
-fire_onchange=''
+quote() { printf '%s\n' "$*" | sed "s/'/'\\\\''/g;1s/^/'/;\$s/\$/'/"; }
+
+destination="/${__object_id:?}"
+state_should=$(cat "${__object:?}/parameter/state")
+stat_file="${__object:?}/explorer/stat"
+fire_onchange=false
 
 get_current_value() {
-	if [ -s "$stat_file" ]; then
-		_name="$1"
-		_value="$2"
-		case "$_value" in
-			[0-9]*)
+	if test -s "${stat_file}"
+	then
+		_name=$1
+		_value=$2
+		case ${_value}
+		in
+			([0-9]*)
 				_index=2
 				;;
-			*)
+			(*)
 				_index=3
 				;;
 		esac
-		awk '/'"$_name"':/ { print $'$_index' }' "$stat_file"
+		awk "/${_name}:/ { print \$$((_index)) }" "${stat_file}"
 		unset _name _value _index
 	fi
 }
 
 set_group() {
-	echo "chgrp '$1' '$destination'"
-	echo "chgrp '$1'" >> "$__messages_out"
-	fire_onchange=1
+	printf 'chgrp %s %s\n' "$(quote "$1")" "$(quote "${destination}")"
+	printf 'chgrp %s\n' "$(quote "$1")" >>"${__messages_out:?}"
+	fire_onchange=true
 }
 
 set_owner() {
-	echo "chown '$1' '$destination'"
-	echo "chown '$1'" >> "$__messages_out"
-	fire_onchange=1
+	printf 'chown %s %s\n' "$(quote "$1")" "$(quote "${destination}")"
+	printf 'chown %s\n' "$(quote "$1")" >>"${__messages_out:?}"
+	fire_onchange=true
 }
 
 set_mode() {
-	echo "chmod '$1' '$destination'"
-	echo "chmod '$1'" >> "$__messages_out"
-	fire_onchange=1
+	printf 'chmod %s %s\n' "$(quote "$1")" "$(quote "${destination}")"
+	printf 'chmod %s\n' "$(quote "$1")" >>"${__messages_out:?}"
+	fire_onchange=true
 }
 
-case "$state_should" in
-	present|exists)
-		if [ -f "$__object/files/upload-destination" ]; then
-			final_destination="$destination"
+case ${state_should}
+in
+	(present|exists)
+		if test -f "${__object:?}/files/upload-destination"
+		then
+			final_destination=${destination}
 			# We change the 'global' $destination variable here so we can
 			# change attributes of the new/uploaded file before moving it
 			# to it's final destination.
-			destination="$(cat "$__object/files/upload-destination")"
+			destination=$(cat "${__object:?}/files/upload-destination")
 		fi
+
 		# Note: Mode - needs to happen last as a chown/chgrp can alter mode by
 		#  clearing S_ISUID and S_ISGID bits (see chown(2))
-		for attribute in group owner mode; do
-			if [ -f "$__object/parameter/$attribute" ]; then
-				value_should="$(cat "$__object/parameter/$attribute")"
+		for attribute in group owner mode
+		do
+			test -f "${__object:?}/parameter/${attribute}" || continue
 
-				# format mode in four digits => same as stat returns
-				if [ "$attribute" = mode ]; then
-					# Convert to four-digit octal number (printf interprets
-					# strings with leading 0s as octal!)
-					value_should=$(printf '%04o' "0${value_should}")
-				fi
+			value_should=$(cat "${__object:?}/parameter/${attribute}")
 
-				value_is="$(get_current_value "$attribute" "$value_should")"
-				if [ -f "$__object/files/set-attributes" ] || [ "$value_should" != "$value_is" ]; then
-					"set_$attribute" "$value_should"
-				fi
+			# format mode in four digits => same as stat returns
+			if test "${attribute}" = 'mode' && expr "${value_should}" : '[0-9]' >/dev/null
+			then
+				# Convert to four-digit octal number (printf interprets
+				# strings with leading 0s as octal!)
+				value_should=$(printf '%04o' "0${value_should}")
+			fi
+
+			value_is=$(get_current_value "${attribute}" "${value_should}")
+			if test -f "${__object:?}/files/file-uploaded" \
+			|| test "${value_should}" != "${value_is}"
+			then
+				"set_${attribute}" "${value_should}"
 			fi
 		done
-		if [ -f "$__object/files/upload-destination" ]; then
+
+		if test -n "${final_destination-}"
+		then
 			# move uploaded file into place
-			printf 'rm -rf "%s"\n' "$final_destination"
-			printf 'mv "%s" "%s"\n' "$destination" "$final_destination"
-		fi
-		if [ -f "$__object/files/set-attributes" ]; then
-			# set-attributes is created if file is created or uploaded in gencode-local
-			fire_onchange=1
+			# printf 'rm -rf %s\n' "$(quote "${final_destination}")"
+			printf 'mv -f %s %s\n' "$(quote "${destination}")" "$(quote "${final_destination}")"
 		fi
 		;;
-
-	absent)
-		if [ "$type" = "file" ] || [ "$type" = "symlink" ]; then
-			echo "rm -f '$destination'"
-			echo remove >> "$__messages_out"
-			fire_onchange=1
-		fi
+	(pre-exists)
 		;;
-
-	pre-exists)
-		:
+	(absent)
+		type_is=$(cat "${__object:?}/explorer/type")
+		case ${type_is}
+		in
+			(file|symlink)
+				printf 'rm -f %s\n' "$(quote "${destination}")"
+				echo remove >>"${__messages_out:?}"
+				fire_onchange=true
+				;;
+		esac
 		;;
-
-	*)
-		echo "Unknown state: $state_should" >&2
+	(*)
+		printf 'Invalid --state: %s\n' "${state_should}" >&2
 		exit 1
 		;;
 esac
 
-if [ -f "$__object/parameter/onchange" ]; then
-	if [ -n "$fire_onchange" ]; then
-		cat "$__object/parameter/onchange"
-	fi
+if ${fire_onchange?} && test -s "${__object:?}/parameter/onchange"
+then
+	cat "${__object:?}/parameter/onchange"
 fi

--- a/type/__file/gencode-remote
+++ b/type/__file/gencode-remote
@@ -12,7 +12,7 @@
 #
 # cdist is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
@@ -26,99 +26,99 @@ stat_file="$__object/explorer/stat"
 fire_onchange=''
 
 get_current_value() {
-    if [ -s "$stat_file" ]; then
-        _name="$1"
-        _value="$2"
-        case "$_value" in
-            [0-9]*)
-                _index=2
-            ;;
-            *)
-                _index=3
-            ;;
-        esac
-        awk '/'"$_name"':/ { print $'$_index' }' "$stat_file"
-        unset _name _value _index
-    fi
+	if [ -s "$stat_file" ]; then
+		_name="$1"
+		_value="$2"
+		case "$_value" in
+			[0-9]*)
+				_index=2
+				;;
+			*)
+				_index=3
+				;;
+		esac
+		awk '/'"$_name"':/ { print $'$_index' }' "$stat_file"
+		unset _name _value _index
+	fi
 }
 
 set_group() {
-    echo "chgrp '$1' '$destination'"
-    echo "chgrp '$1'" >> "$__messages_out"
-    fire_onchange=1
+	echo "chgrp '$1' '$destination'"
+	echo "chgrp '$1'" >> "$__messages_out"
+	fire_onchange=1
 }
 
 set_owner() {
-    echo "chown '$1' '$destination'"
-    echo "chown '$1'" >> "$__messages_out"
-    fire_onchange=1
+	echo "chown '$1' '$destination'"
+	echo "chown '$1'" >> "$__messages_out"
+	fire_onchange=1
 }
 
 set_mode() {
-    echo "chmod '$1' '$destination'"
-    echo "chmod '$1'" >> "$__messages_out"
-    fire_onchange=1
+	echo "chmod '$1' '$destination'"
+	echo "chmod '$1'" >> "$__messages_out"
+	fire_onchange=1
 }
 
 case "$state_should" in
-    present|exists)
-        if [ -f "$__object/files/upload-destination" ]; then
-            final_destination="$destination"
-            # We change the 'global' $destination variable here so we can
-            # change attributes of the new/uploaded file before moving it
-            # to it's final destination.
-            destination="$(cat "$__object/files/upload-destination")"
-        fi
-        # Note: Mode - needs to happen last as a chown/chgrp can alter mode by
-        #  clearing S_ISUID and S_ISGID bits (see chown(2))
-        for attribute in group owner mode; do
-            if [ -f "$__object/parameter/$attribute" ]; then
-                value_should="$(cat "$__object/parameter/$attribute")"
+	present|exists)
+		if [ -f "$__object/files/upload-destination" ]; then
+			final_destination="$destination"
+			# We change the 'global' $destination variable here so we can
+			# change attributes of the new/uploaded file before moving it
+			# to it's final destination.
+			destination="$(cat "$__object/files/upload-destination")"
+		fi
+		# Note: Mode - needs to happen last as a chown/chgrp can alter mode by
+		#  clearing S_ISUID and S_ISGID bits (see chown(2))
+		for attribute in group owner mode; do
+			if [ -f "$__object/parameter/$attribute" ]; then
+				value_should="$(cat "$__object/parameter/$attribute")"
 
-                # format mode in four digits => same as stat returns
-                if [ "$attribute" = mode ]; then
-                    # Convert to four-digit octal number (printf interprets
-                    # strings with leading 0s as octal!)
-                    value_should=$(printf '%04o' "0${value_should}")
-                fi
+				# format mode in four digits => same as stat returns
+				if [ "$attribute" = mode ]; then
+					# Convert to four-digit octal number (printf interprets
+					# strings with leading 0s as octal!)
+					value_should=$(printf '%04o' "0${value_should}")
+				fi
 
-                value_is="$(get_current_value "$attribute" "$value_should")"
-                if [ -f "$__object/files/set-attributes" ] || [ "$value_should" != "$value_is" ]; then
-                    "set_$attribute" "$value_should"
-                fi
-            fi
-        done
-        if [ -f "$__object/files/upload-destination" ]; then
-            # move uploaded file into place
-            printf 'rm -rf "%s"\n' "$final_destination"
-            printf 'mv "%s" "%s"\n' "$destination" "$final_destination"
-        fi
-        if [ -f "$__object/files/set-attributes" ]; then
-            # set-attributes is created if file is created or uploaded in gencode-local
-            fire_onchange=1
-        fi
-    ;;
+				value_is="$(get_current_value "$attribute" "$value_should")"
+				if [ -f "$__object/files/set-attributes" ] || [ "$value_should" != "$value_is" ]; then
+					"set_$attribute" "$value_should"
+				fi
+			fi
+		done
+		if [ -f "$__object/files/upload-destination" ]; then
+			# move uploaded file into place
+			printf 'rm -rf "%s"\n' "$final_destination"
+			printf 'mv "%s" "%s"\n' "$destination" "$final_destination"
+		fi
+		if [ -f "$__object/files/set-attributes" ]; then
+			# set-attributes is created if file is created or uploaded in gencode-local
+			fire_onchange=1
+		fi
+		;;
 
-    absent)
-        if [ "$type" = "file" ] || [ "$type" = "symlink" ]; then
-            echo "rm -f '$destination'"
-            echo remove >> "$__messages_out"
-            fire_onchange=1
-        fi
-    ;;
+	absent)
+		if [ "$type" = "file" ] || [ "$type" = "symlink" ]; then
+			echo "rm -f '$destination'"
+			echo remove >> "$__messages_out"
+			fire_onchange=1
+		fi
+		;;
 
-    pre-exists)
-        :
-        ;;
+	pre-exists)
+		:
+		;;
 
-    *)
-        echo "Unknown state: $state_should" >&2
-        exit 1
-    ;;
+	*)
+		echo "Unknown state: $state_should" >&2
+		exit 1
+		;;
 esac
 
 if [ -f "$__object/parameter/onchange" ]; then
-    if [ -n "$fire_onchange" ]; then
-        cat "$__object/parameter/onchange"
-    fi
+	if [ -n "$fire_onchange" ]; then
+		cat "$__object/parameter/onchange"
+	fi
 fi


### PR DESCRIPTION
When trying to experiment with atomic file copies (possibly without `scp(1)`) I came to the conclusion that the age of the `__file` type really shows.  

So I did some modernisation first:
* use tabs for indentation everywhere
* add `:?` "guards" to cdist environment variables
* fix an ordering error when detecting symlinks
* try to make the logic in `gencode-*` more succinct.

I didn't yet extensively test the changes, but I still wanted to put the changes out for others to see, because the type is very important and more eyes see more.