### PR TITLE
Add support for Sortix in essential types

### DIFF
--- a/explorer/disks
+++ b/explorer/disks
@@ -69,6 +69,19 @@ case $uname_s in
               -e 's/^ *[0-9]\{1,\}\. //p' \
         | cut -d ' ' -f 1
     ;;
+    Sortix)
+        if command -v disked >/dev/null 2>&1
+        then
+            printf '%s\n' devices exit \
+            | disked \
+            | awk '
+              /^#[ \t]/ { t = 1; for (i = 1; i <= NF; i++) cols[$i] = i }
+              t && $cols["#"] ~ /^[0-9]+$/ {
+                  print $cols["DEVICE"]
+              }
+              '
+        fi
+    ;;
     *)
         printf "Don't know how to list disks for %s operating system.\n" "${uname_s}" >&2
         printf 'If you can please submit a patch\n' >&2

--- a/explorer/init
+++ b/explorer/init
@@ -2,7 +2,7 @@
 #
 # 2016 Daniel Heule (hda at sfs.biz)
 # Copyright 2017, Philippe Gregoire <pg@pgregoire.xyz>
-# 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2020,2022 Dennis Camera (skonfig at dtnr.ch)
 #
 # This file is part of cdist.
 #
@@ -66,6 +66,9 @@
 #
 # Solaris/Illumos:
 #   smf, init???
+#
+# Sortix:
+#   init
 
 # NOTE: init systems can be stacked. This is popular to run OpenRC on top of
 # sysvinit (Gentoo) or busybox-init (Alpine), but can also be used to run runit
@@ -411,6 +414,9 @@ find_init() {
 			;;
 		Darwin|SunOS)
 			find_init_ps
+			;;
+		Sortix)
+			echo 'init'
 			;;
 		*)
 			echo "Don't know how to determine init." >&2

--- a/explorer/interfaces
+++ b/explorer/interfaces
@@ -1,6 +1,8 @@
 #!/bin/sh -e
 #
+# 2012 Sébastien Gross <seb•ɑƬ•chezwam•ɖɵʈ•org>
 # 2019 Ander Punnar (ander-at-kvlt-dot-ee)
+# 2022 Dennis Camera (skonfig at dtnr.ch)
 #
 # This file is part of cdist.
 #
@@ -23,6 +25,15 @@ then
 	ip -o link show | sed -n 's/^[0-9]\+: \(.\+\): <.*/\1/p'
 elif command -v ifconfig >/dev/null
 then
-	ifconfig -a | sed -n -E 's/^(.*)(:[[:space:]]*flags=|Link encap).*/\1/p'
+	case $(uname -s)
+	in
+		(Sortix)
+			ifconfig | sed -n -e 's/^\([^[:space:]]*\):$/\1/p'
+			;;
+		(*)
+			ifconfig -a \
+			| sed -n -E 's/^(.*)(:[[:space:]]*flags=|Link encap).*/\1/p'
+			;;
+	esac
 fi \
- | sort -u
+| sort -u

--- a/explorer/memory
+++ b/explorer/memory
@@ -3,7 +3,7 @@
 # 2014 Daniel Heule  (hda at sfs.biz)
 # 2014 Thomas Oettli (otho at sfs.biz)
 # Copyright 2017, Philippe Gregoire <pg@pgregoire.xyz>
-# 2020 Dennis Camera <dennis.camera at ssrq-sds-fds.ch>
+# 2020,2022 Dennis Camera (skonfig at dtnr.ch)
 #
 # This file is part of cdist.
 #
@@ -27,11 +27,13 @@
 str2bytes() {
 	awk -F' ' '
 	$2 ==   "B" || !$2 { print $1 }
-	$2 ==  "kB" { printf "%.f\n", ($1 * 1000) }
+	$2 ==  "kB" ||
+	$2 ==  "KB" { printf "%.f\n", ($1 * 1000) }
 	$2 ==  "MB" { printf "%.f\n", ($1 * 1000 * 1000) }
 	$2 ==  "GB" { printf "%.f\n", ($1 * 1000 * 1000 * 1000) }
 	$2 ==  "TB" { printf "%.f\n", ($1 * 1000 * 1000 * 1000 * 1000) }
-	$2 == "kiB" { printf "%.f\n", ($1 * 1024) }
+	$2 == "kiB" ||
+	$2 == "KiB" { printf "%.f\n", ($1 * 1024) }
 	$2 == "MiB" { printf "%.f\n", ($1 * 1024 * 1024) }
 	$2 == "GiB" { printf "%.f\n", ($1 * 1024 * 1024 * 1024) }
 	$2 == "TiB" { printf "%.f\n", ($1 * 1024 * 1024 * 1024 * 1024) }'
@@ -39,6 +41,10 @@ str2bytes() {
 
 bytes2kib() {
 	awk '$0 > 0 { printf "%.f\n", ($0 / 1024) }'
+}
+
+sum_lines() {
+	awk '{ sum += $0 } END { printf "%.f\n", sum }'
 }
 
 
@@ -82,6 +88,35 @@ in
 			awk -F ': +' '$1 == "MemTotal" { sub(/B$/, "iB", $2); print $2 }' /proc/meminfo \
 			| str2bytes \
 			| bytes2kib
+		fi
+		;;
+	(Sortix)
+		if command -v memstat >/dev/null 2>&1
+		then
+			memstat \
+			| awk '
+			  NR==1 && /^memory usage: / {
+				  # old format
+				  match($0, /([0-9]+ +[A-Za-z]{0,2}B +)+total/)
+				  total = substr($0, RSTART, RLENGTH)
+				  sub(/ +total$/, "", total)
+				  np = split(total, parts, /B +/)
+				  sub(/B$/, "", parts[np])
+				  for (i = 1; i <= np; i++)
+					  print parts[i] "B"
+				  exit
+			  }
+			  $2 == "total" {
+				  if ($1 ~ /B$/)
+					  sub(/B$/, "", $1)
+				  else
+					  sub(/.$/, " &iB", $1)
+				  print $1
+			  }
+			  ' \
+			| str2bytes \
+			| bytes2kib \
+			| sum_lines
 		fi
 		;;
 	(*)

--- a/explorer/os
+++ b/explorer/os
@@ -2,6 +2,7 @@
 #
 # 2010-2011 Nico Schottelius (nico-cdist at schottelius.org)
 # Copyright 2017, Philippe Gregoire <pg@pgregoire.xyz>
+# 2019-2022 Dennis Camera (skonfig at dtnr.ch)
 #
 # This file is part of cdist.
 #
@@ -141,6 +142,16 @@ case "$uname_s" in
       exit 0
    ;;
 esac
+
+# Hobby OSes
+
+if [ -f /etc/sortix-release ] || [ "${uname_s}" = 'Sortix' ]; then
+   echo sortix
+   exit 0
+fi
+
+
+# Generic os-release file check
 
 if [ -f /etc/os-release ]; then
    # after sles15, suse don't provide an /etc/SuSE-release anymore, but there is almost no difference between sles and opensuse leap, so call it suse

--- a/explorer/os_version
+++ b/explorer/os_version
@@ -172,4 +172,8 @@ in
    alpine)
        cat /etc/alpine-release
    ;;
+   sortix)
+      rc_getvar /etc/sortix-release VERSION_ID
+      # alternatively: kernel release `uname -r`
+   ;;
 esac

--- a/type/__directory/explorer/stat
+++ b/type/__directory/explorer/stat
@@ -19,21 +19,45 @@
 # along with cdist. If not, see <http://www.gnu.org/licenses/>.
 #
 
+os=$("$__explorer/os")
+
 destination="/$__object_id"
+
+passwd_lookup() {
+   # usage: passwd_lookup file needle match_col print_col
+   awk -F ':' -v needle="${2:?}" -v mcol=$((${3:?})) -v pcol=$((${4:?})) '
+   $mcol == needle {
+      print $pcol
+      f = 1
+   }
+   END {
+      if (!f)
+         print "UNKNOWN"
+   }' "${1:?}"
+}
 
 fallback() {
    # Patch the output together, manually
 
-   ls_line=$(ls -ldn "$destination")
+   if test "${os}" != 'sortix'
+   then
+      read -r mode_text links uid gid size _ <<EOF
+$(ls -ldn "${destination}")
+EOF
 
-   uid=$(echo "$ls_line" | awk '{ print $3 }')
-   gid=$(echo "$ls_line" | awk '{ print $4 }')
+      owner=$(passwd_lookup /etc/passwd $((uid)) 3 1)
+      group=$(passwd_lookup /etc/group $((gid)) 3 1)
+   else
+      # NOTE: Sortix' ls(1) does not currently support the -n option
+      read -r mode_text links owner group size _ <<EOF
+$(ls -ld "${destination}")
+EOF
 
-   owner=$(awk -F: -v uid="$uid" '$3 == uid { print $1; f=1 } END { if (!f) print "UNKNOWN" }' /etc/passwd)
-   group=$(awk -F: -v gid="$gid" '$3 == gid { print $1; f=1 } END { if (!f) print "UNKNOWN" }' /etc/group)
+      uid=$(passwd_lookup /etc/passwd "${owner}" 1 3)
+      gid=$(passwd_lookup /etc/group "${group}" 1 3)
+   fi
 
-   mode_text=$(echo "$ls_line" | awk '{ print $1 }')
-   mode=$(echo "$mode_text" | awk '{for(i=8;i>=0;--i){c=substr($1,10-i,1);k+=((c~/[rwxst]/)*2^i);if(!(i%3))k+=(tolower(c)~/[lst]/)*2^(9+i/3)}printf("%04o",k)}')
+   mode=$(echo "${mode_text}" | awk '{for(i=8;i>=0;--i){c=substr($1,10-i,1);k+=((c~/[rwxst]/)*2^i);if(!(i%3))k+=(tolower(c)~/[lst]/)*2^(9+i/3)}printf("%04o",k)}')
 
    printf 'type: %s\nowner: %d %s\ngroup: %d %s\nmode: %s %s\n' \
       "$("$__type_explorer/type")" \
@@ -50,7 +74,7 @@ command -v stat >/dev/null 2>&1 || {
    exit
 }
 
-case $("$__explorer/os")
+case ${os}
 in
    freebsd|netbsd|openbsd|macosx)
       stat -f 'type: %HT
@@ -58,6 +82,11 @@ owner: %Du %Su
 group: %Dg %Sg
 mode: %Mp%03Lp %Sp
 ' "$destination" | awk '/^type/ { print tolower($0); next } { print }'
+      ;;
+   sortix)
+      # NOTE: currently, Sortix' stat(1) does not allow specifying a
+      #       format string.
+      fallback
       ;;
    *)
       # NOTE: Do not use --printf here as it is not supported by BusyBox stat.

--- a/type/__file/explorer/stat
+++ b/type/__file/explorer/stat
@@ -20,24 +20,45 @@
 # along with cdist. If not, see <http://www.gnu.org/licenses/>.
 #
 
+os=$("$__explorer/os")
+
 destination="/$__object_id"
+
+passwd_lookup() {
+   # usage: passwd_lookup file needle match_col print_col
+   awk -F ':' -v needle="${2:?}" -v mcol=$((${3:?})) -v pcol=$((${4:?})) '
+   $mcol == needle {
+      print $pcol
+      f = 1
+   }
+   END {
+      if (!f)
+         print "UNKNOWN"
+   }' "${1:?}"
+}
 
 fallback() {
    # Fallback: Patch the output together, manually.
 
-   ls_line=$(ls -ldn "$destination")
+   if test "${os}" != 'sortix'
+   then
+      read -r mode_text links uid gid size _ <<EOF
+$(ls -ldn "${destination}")
+EOF
 
-   uid=$(echo "$ls_line" | awk '{ print $3 }')
-   gid=$(echo "$ls_line" | awk '{ print $4 }')
+      owner=$(passwd_lookup /etc/passwd $((uid)) 3 1)
+      group=$(passwd_lookup /etc/group $((gid)) 3 1)
+   else
+      # NOTE: Sortix' ls(1) does not currently support the -n option
+      read -r mode_text links owner group size _ <<EOF
+$(ls -ld "${destination}")
+EOF
 
-   owner=$(awk -F: -v uid="$uid" '$3 == uid { print $1; f=1 } END { if (!f) print "UNKNOWN" }' /etc/passwd)
-   group=$(awk -F: -v gid="$gid" '$3 == gid { print $1; f=1 } END { if (!f) print "UNKNOWN" }' /etc/group)
+      uid=$(passwd_lookup /etc/passwd "${owner}" 1 3)
+      gid=$(passwd_lookup /etc/group "${group}" 1 3)
+   fi
 
-   mode_text=$(echo "$ls_line" | awk '{ print $1 }')
-   mode=$(echo "$mode_text" | awk '{for(i=8;i>=0;--i){c=substr($1,10-i,1);k+=((c~/[rwxst]/)*2^i);if(!(i%3))k+=(tolower(c)~/[lst]/)*2^(9+i/3)}printf("%04o",k)}')
-
-   size=$(echo "$ls_line" | awk '{ print $5 }')
-   links=$(echo "$ls_line" | awk '{ print $2 }')
+   mode=$(echo "${mode_text}" | awk '{for(i=8;i>=0;--i){c=substr($1,10-i,1);k+=((c~/[rwxst]/)*2^i);if(!(i%3))k+=(tolower(c)~/[lst]/)*2^(9+i/3)}printf("%04o",k)}')
 
    printf 'type: %s\nowner: %d %s\ngroup: %d %s\nmode: %s %s\nsize: %d\nlinks: %d\n' \
       "$("$__type_explorer/type")" \
@@ -59,7 +80,7 @@ command -v stat >/dev/null 2>&1 || {
 }
 
 
-case $("$__explorer/os")
+case ${os}
 in
    freebsd|netbsd|openbsd|macosx)
       stat -f 'type: %HT
@@ -69,6 +90,11 @@ mode: %Mp%03Lp %Sp
 size: %Dz
 links: %Dl
 ' "$destination" | awk '/^type/ { print tolower($0); next } { print }'
+      ;;
+   sortix)
+      # NOTE: currently, Sortix' stat(1) does not allow specifying a
+      #       format string.
+      fallback
       ;;
    *)
       # NOTE: Do not use --printf here as it is not supported by BusyBox stat.

--- a/type/__hostname/gencode-remote
+++ b/type/__hostname/gencode-remote
@@ -67,7 +67,7 @@ in
             "&& hostnamectl set-hostname '${name_should}'" \
             "|| hostname '${name_should}'"
         ;;
-    (centos|fedora|redhat|scientific|freebsd|netbsd|openbsd|gentoo|void)
+    (centos|fedora|redhat|scientific|freebsd|netbsd|openbsd|gentoo|sortix|void)
         echo "hostname '${name_should}'"
         ;;
     (openwrt)

--- a/type/__hostname/manifest
+++ b/type/__hostname/manifest
@@ -56,7 +56,7 @@ fi
 
 case ${os}
 in
-    (alpine|debian|devuan|ubuntu|void)
+    (alpine|debian|devuan|sortix|ubuntu|void)
         echo "${name_should}" | __file /etc/hostname --source -
         ;;
     (archlinux)

--- a/type/__sshd_config/explorer/config_file
+++ b/type/__sshd_config/explorer/config_file
@@ -46,6 +46,14 @@ else
 				echo '/etc/sshd_config'
 			fi
 			;;
+		(sortix)
+			if test -e '/etc/sshd_config'
+			then
+				echo '/etc/sshd_config'
+			else
+				echo '/etc/default/sshd_config'
+			fi
+			;;
 		(*)
 			echo '/etc/ssh/sshd_config'
 			;;

--- a/type/__sshd_config/gencode-remote
+++ b/type/__sshd_config/gencode-remote
@@ -19,6 +19,7 @@
 #
 
 joinlines() { sed -n -e H -e "\${x;s/^\\n//;s/\\n/${1:?}/g;p;}"; }
+fnmatch() { case $2 in ($1) return 0;; (*) return 1;; esac; }
 
 state_is=$(cat "${__object:?}/explorer/state")
 state_should=$(cat "${__object:?}/parameter/state")
@@ -49,14 +50,36 @@ quote() { printf "'%s'" "$(printf '%s' "$*" | sed -e "s/'/'\\\\''/g")"; }
 drop_awk_comments() { quote "$(sed '/^[[:blank:]]*#.*$/d;/^$/d' "$@")"; }
 
 # Ensure the sshd_config file is there
-cat <<EOF
-test -e $(quote "${sshd_config_file}") || {
-	 : >$(quote "${sshd_config_file}")
-	 chown 0:0 $(quote "${sshd_config_file}")
-	 chmod 0644 $(quote "${sshd_config_file}")
-}
+read -r os <"${__global:?}/explorer/os"
+if test "${os}" = 'sortix'
+then
+	if test ! -f "${__object:?}/parameter/file" \
+		&& fnmatch '/etc/default/*' "${sshd_config_file}"
+	then
+		# Sortix installs a fallback/default configuration to
+		# /etc/default/sshd_config, but expects user modifications
+		# in /etc/sshd_config, so if missing the config_file
+		# explorer returns an /etc/default path and we copy the
+		# default configuration file to the user location first.
+		# This is ignored if the user used --file.
+		sshd_config_file_user=/etc/${sshd_config_file#/etc/default/}
+		printf 'cp -p %s %s\n' \
+			"$(quote "${sshd_config_file}")" \
+			"$(quote "${sshd_config_file_user}")"
+		sshd_config_file=${sshd_config_file_user}
+		unset sshd_config_file_user
+	fi
+else
+	cat <<-EOF
+	test -e $(quote "${sshd_config_file}") || {
+	    : >$(quote "${sshd_config_file}")
+	    chown 0:0 $(quote "${sshd_config_file}")
+	    chmod 0644 $(quote "${sshd_config_file}")
+	}
+	
+	EOF
+fi
 
-EOF
 
 match_only=
 if test -s "${__object:?}/parameter/match"

--- a/type/__sshd_config/manifest
+++ b/type/__sshd_config/manifest
@@ -48,6 +48,11 @@ in
 		# If dropbear is used, the state explorer will already fail because it
 		# cannot find the sshd binary.
 		;;
+	(sortix)
+		# whitelist
+		# requires `tix-port ssh`, but currently all ports are always
+		# installed in Sortix.
+		;;
 	(*)
 		: "${__type:?}"  # make shellcheck happy
 		printf 'Your operating system (%s) is currently not supported by this type (%s)\n' \


### PR DESCRIPTION
I couldn't hold myself back from adding support for the [Sortix](https://sortix.org) hobby OS.

There's two issues still left (those are bugs and unimplemented features on Sortix' side):
* `explorer/memory`:
  * The `%.f` format isn't implemented
* `explorer/{disks,interfaces}`:
  * `disked`/`ifconfig` fail when trying to open `/dev/tty` over a non-interactive SSH session; a workaround is to use `ssh -tt`
* `type/__file`:
  * there is no `cksum(1)` so the `cksum` explorer fails; a workaround is to install a Python-based `cksum` replacement manually.
  * I needed to add a workaround in the `stat` explorer until Sortix' `ls(1)` supports `-n`