### PR TITLE
Clean up missing variables issue in __apt_source

### DIFF
--- a/type/__apt_source/files/source.list.template
+++ b/type/__apt_source/files/source.list.template
@@ -1,5 +1,4 @@
-#!/bin/sh -e
-set -u
+#!/bin/sh -e -u
 
 entry="$uri $distribution $component"
 options="${forcedarch-} ${signed_by-}"

--- a/type/__apt_source/files/source.list.template
+++ b/type/__apt_source/files/source.list.template
@@ -1,15 +1,9 @@
-#!/bin/sh
+#!/bin/sh -e
 set -u
 
 entry="$uri $distribution $component"
-if test -n "${forcedarch-}"
-then
-   options=${options-}${options:+ }${forcedarch}
-fi
-if test -n "${signed_by-}"
-then
-   options=${options-}${options:+ }${signed_by}
-fi
+options="${forcedarch-} ${signed_by-}"
+options=${options## }; options=${options%% } # Trim spaces from either end
 
 cat << DONE
 # Created by cdist ${__type##*/}

--- a/type/__apt_source/manifest
+++ b/type/__apt_source/manifest
@@ -35,7 +35,7 @@ if [ -f "$__object/parameter/arch" ]; then
 fi
 
 if [ -f "$__object/parameter/signed-by" ]; then
-   signed_by="${signed_by:${signed_by} }signed-by=$(sed -e ':a' -e '$!N' -e 's/\n/,/' -e 'ta' "$__object/parameter/signed-by")"
+   signed_by="signed-by=$(sed -e ':a' -e '$!N' -e 's/\n/,/' -e 'ta' "$__object/parameter/signed-by")"
 fi
 
 if [ "$options" ]; then
@@ -47,7 +47,8 @@ export name
 export uri
 export distribution
 export component
-export options
+export forcedarch
+export signed_by
 
 # generate file from template
 mkdir "$__object/files"

--- a/type/__apt_source/manifest
+++ b/type/__apt_source/manifest
@@ -35,11 +35,8 @@ if [ -f "$__object/parameter/arch" ]; then
 fi
 
 if [ -f "$__object/parameter/signed-by" ]; then
+   # Take all '--signed-by' parameter values present on separate lines and join them with a comma
    signed_by="signed-by=$(sed -e ':a' -e '$!N' -e 's/\n/,/' -e 'ta' "$__object/parameter/signed-by")"
-fi
-
-if [ "$options" ]; then
-    options="[$options]"
 fi
 
 # export variables for use in template


### PR DESCRIPTION
Fixing the problem in the manifest and the template that caused the issues, hence undoing the previous fix.

### Context

Original implementation by @fancsali failed to export appropriate variables (`signed_by` and `forcedarch`) from the manifest to the template, so the template was missing those every time - whether the actual parameters have been provided in the first place or not.

The missing or unset variables in the template caused an issue anyway, as the template is coded in a defensive way, and forces variables to be set by calling `set -u`.

The immediate issue of the template failing was addressed in 2277ec5 by @sideeffect42 when merging the code.

However, I discovered the original issue of the parameters never making through (even if set) recently - which essentially made those completely ignored and useless.

### Fix approach

Reverting the fix (2277ec5), and re-doing the original solution properly:

* Export `forcedarch` and `signed_by` in the `manifest`
* Update the template to use a default empty value if those are unset - so we can keep `set -u` for safety
* Re-introducing the  "append and trim" logic, to keep the template short and concise