### PR TITLE
Fix shebang line

### DIFF
--- a/type/__apt_source/files/source.list.template
+++ b/type/__apt_source/files/source.list.template
@@ -1,4 +1,4 @@
-#!/bin/sh -e -u
+#!/bin/sh -eu
 
 entry="$uri $distribution $component"
 options="${forcedarch-} ${signed_by-}"


### PR DESCRIPTION
Okay, ladies and gents, please don't kill me... 😳 

Turns out, this works

```
bash$ sh -e -u
$
```

However, saying the same on a shebang line in a file

```
#!/bin/sh -e -u
...
```

and then running it, would return an error:

```
./test.sh
sh: 0: Illegal option -
```