### PR TITLE
__link: fix type explorer for symbolic links with missing source

### DIFF
--- a/type/__link/explorer/state
+++ b/type/__link/explorer/state
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 #
 # 2012-2014 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2023 Dennis Camera (dennis.camera at riiengineering.ch)
@@ -19,9 +19,9 @@
 # along with cdist. If not, see <http://www.gnu.org/licenses/>.
 #
 
-destination="/$__object_id"
-type="$(cat "$__object/parameter/type")"
-source="$(cat "$__object/parameter/source")"
+destination="/${__object_id:?}"
+type=$(cat "${__object:?}/parameter/type")
+source=$(cat "${__object:?}/parameter/source")
 
 _readlink() {
 	if command -v readlink >/dev/null 2>&1
@@ -42,11 +42,9 @@ _readlink() {
 	fi
 }
 
-destination_dir="${destination%/*}"
-
-case "$type" in
+case ${type}
+in
    symbolic)
-      cd "$destination_dir" || exit 1
       if [ -h "$destination" ]; then
          source_is=$(_readlink "${destination}")
          # ignore trailing slashes for comparison
@@ -60,28 +58,32 @@ case "$type" in
       fi
    ;;
    hard)
-      cd "$destination_dir" || exit 1
-      # check source relative to destination_dir
-      if [ ! -e "$source" ]; then
+      cd "${destination%/*}" || exit 1
+      # check source relative to destination dir
+      if [ ! -e "${source}" ]; then
          echo sourcemissing
+         exit 0
+      fi
+      if [ ! -e "${destination}" ]; then
+         echo absent
          exit 0
       fi
       # Currently not worth the effor to change it, stat is not defined by POSIX
       # and different OSes has different implementations for it.
       # shellcheck disable=SC2012
-      destination_inode=$(ls -i "$destination" | awk '{print $1}')
+      destination_inode=$(ls -i "${destination}" | awk '{print $1}')
       # Currently not worth the effor to change it, stat is not defined by POSIX
       # and different OSes has different implementations for it.
       # shellcheck disable=SC2012
-      source_inode=$(ls -i "$source" | awk '{print $1}')
-      if [ "$destination_inode" -eq "$source_inode" ]; then
+      source_inode=$(ls -i "${source}" | awk '{print $1}')
+      if [ "${destination_inode}" -eq "${source_inode}" ]; then
          echo present
       else
          echo absent
       fi
    ;;
    *)
-      echo "Unknown type: $type" >&2
+      echo "Unknown type: ${type}" >&2
       exit 1
    ;;
 esac

--- a/type/__link/explorer/state
+++ b/type/__link/explorer/state
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 # 2012-2014 Steven Armstrong (steven-cdist at armstrong.cc)
-# 2022 Dennis Camera (cdist at dtnr.ch)
+# 2023 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of cdist.
 #
@@ -22,12 +22,6 @@
 destination="/$__object_id"
 type="$(cat "$__object/parameter/type")"
 source="$(cat "$__object/parameter/source")"
-
-# no destination? -> state is absent
-if [ ! -e "$destination" ]; then
-   echo absent
-   exit 0
-fi
 
 _readlink() {
 	if command -v readlink >/dev/null 2>&1

--- a/type/__link/explorer/type
+++ b/type/__link/explorer/type
@@ -1,6 +1,7 @@
 #!/bin/sh
 #
 # 2013 Steven Armstrong (steven-cdist armstrong.cc)
+# 2023 Dennis Camera (dennis.camera at riiengineering.ch
 #
 # This file is part of cdist.
 #
@@ -23,10 +24,12 @@
 
 destination="/$__object_id"
 
-if [ ! -e "$destination" ]; then
-    echo none
-elif [ -h "$destination" ]; then
+# NOTE: Test for symlink first because a symlink can exist but point to a
+#       non-existing file, in which case `test -h` is 0 but `test -e` is 1.
+if [ -h "$destination" ]; then
     echo symlink
+elif [ ! -e "$destination" ]; then
+    echo none
 elif [ -f "$destination" ]; then
     type="$(cat "$__object/parameter/type")"
     case "$type" in


### PR DESCRIPTION
When using `__link` to create a symbolic link with a non-existing `--source` (e.g. one being created by a cron job), the `type` explorer will always (incorrectly) report `none`, making the type recreate the symbolic link on every run.

This is because `test ! -e` returns `0` for a symbolic link whose link destination does not exist. So to fix the behaviour, we `test -h` first, detecting it is a symbolic link.

I also did a little simplification in the `state` explorer: we don't need to `cd` in the `--type symbolic` case, because the sources are compared as strings, not as actual file system paths.