### PR TITLE
Add AlmaLinux, EuroLinux, Rocky Linux distributions

### DIFF
--- a/explorer/os
+++ b/explorer/os
@@ -80,27 +80,65 @@ if [ -f /etc/owl-release ]; then
 fi
 
 ### Redhat and derivatives
-if grep -q ^Scientific /etc/redhat-release 2>/dev/null; then
-    echo scientific
+
+if [ -f /etc/fedora-release ]; then
+    echo fedora
     exit 0
 fi
 
-if grep -q ^CentOS /etc/redhat-release 2>/dev/null; then
+if [ -f /etc/almalinux-release ]; then
+    echo almalinux
+    exit 0
+fi
+
+if [ -f /etc/rocky-release ]; then
+    echo rocky
+    exit 0
+fi
+
+# NOTE: check for centos-release after checking for AlmaLinux/Rocky Linux,
+#       because these two also have a centos-release file.
+if [ -f /etc/centos-release ]; then
     echo centos
     exit 0
 fi
 
-if grep -q ^Fedora /etc/redhat-release 2>/dev/null; then
-   echo fedora
-   exit 0
-fi
-
-if grep -q ^Mitel /etc/redhat-release 2>/dev/null; then
-   echo mitel
-   exit 0
-fi
-
 if [ -f /etc/redhat-release ]; then
+   if grep -q '^CentOS ' /etc/redhat-release; then
+       echo centos
+       exit 0
+   fi
+
+   if grep -q '^Fedora ' /etc/redhat-release; then
+      echo fedora
+      exit 0
+   fi
+
+   if grep -q '^AlmaLinux ' /etc/redhat-release; then
+      echo almalinux
+      exit 0
+   fi
+
+   if grep -q '^Rocky Linux ' /etc/redhat-release; then
+      echo rocky
+      exit 0
+   fi
+
+   if grep -q '^EuroLinux ' /etc/redhat-release; then
+       echo eurolinux
+       exit 0
+   fi
+
+   if grep -q ^Scientific /etc/redhat-release; then
+       echo scientific
+       exit 0
+   fi
+
+   if grep -q ^Mitel /etc/redhat-release; then
+      echo mitel
+      exit 0
+   fi
+
    echo redhat
    exit 0
 fi

--- a/explorer/os_version
+++ b/explorer/os_version
@@ -143,7 +143,7 @@ in
    owl)
       cat /etc/owl-release
    ;;
-   redhat|centos|mitel|scientific)
+   redhat|centos|almalinux|eurolinux|rocky|mitel|scientific)
       cat /etc/redhat-release
    ;;
    slackware)

--- a/type/__locale/manifest
+++ b/type/__locale/manifest
@@ -30,7 +30,7 @@ case "$os" in
         # Debian needs a seperate package
         __package locales --state present
     ;;
-    archlinux|suse|ubuntu|scientific|centos|alpine)
+    archlinux|suse|ubuntu|scientific|centos|almalinux|eurolinux|rocky|alpine)
         :
     ;;
     *)

--- a/type/__localedef/gencode-remote
+++ b/type/__localedef/gencode-remote
@@ -61,7 +61,7 @@ in
 		printf '%s does not support locales.\n' "${os}" >&2
 		exit 1
 		;;
-	(archlinux|debian|devuan|ubuntu|suse|centos|fedora|redhat|scientific)
+	(archlinux|debian|devuan|ubuntu|suse|centos|almalinux|eurolinux|rocky|fedora|redhat|scientific)
 		# FIXME: The code below only works for glibc-based installations.
 
 		# NOTE: Hardcoded, create a pull request in case it is at another

--- a/type/__package/manifest
+++ b/type/__package/manifest
@@ -31,7 +31,7 @@ else
    # By default determine package manager based on operating system
    os="$(cat "$__global/explorer/os")"
    case "$os" in
-         amazon|scientific|centos|fedora|redhat) type="yum" ;;
+         amazon|scientific|centos|almalinux|eurolinux|rocky|fedora|redhat) type="yum" ;;
          archlinux) type="pacman" ;;
          debian|ubuntu|devuan) type="apt" ;;
          freebsd)

--- a/type/__package_yum/gencode-remote
+++ b/type/__package_yum/gencode-remote
@@ -37,7 +37,7 @@ fi
 
 state_should="$(cat "$__object/parameter/state")"
 
-if grep -q -E "(scientific|centos|redhat|amazon)" "$__global/explorer/os"; then
+if grep -q -E "(scientific|centos|almalinux|eurolinux|rocky|redhat|amazon)" "$__global/explorer/os"; then
     opts="-y --quiet"
 else
     opts="--assumeyes --quiet"

--- a/type/__sshd_config/manifest
+++ b/type/__sshd_config/manifest
@@ -24,7 +24,7 @@ state_should=$(cat "${__object:?}/parameter/state")
 
 case ${os}
 in
-	(alpine|centos|fedora|redhat|scientific|debian|devuan|ubuntu)
+	(alpine|centos|almalinux|eurolinux|rocky|fedora|redhat|scientific|debian|devuan|ubuntu)
 		if test "${state_should}" != 'absent'
 		then
 			__package openssh-server --state present

--- a/type/__start_on_boot/explorer/state
+++ b/type/__start_on_boot/explorer/state
@@ -62,7 +62,7 @@ else
             [ -f "/etc/init/${name}.conf" ] && state="present"
         ;;
 
-        amazon|scientific|centos|fedora|owl|redhat)
+        amazon|scientific|centos|almalinux|eurolinux|rocky|fedora|owl|redhat)
             state=$(chkconfig --level "$runlevel" "$name" || echo absent)
             [ "$state" ] || state="present"
         ;;

--- a/type/__start_on_boot/gencode-remote
+++ b/type/__start_on_boot/gencode-remote
@@ -62,7 +62,7 @@ case "$state_should" in
                     echo "rc-update add '$name' '$target_runlevel'"
                 ;;
 
-                amazon|scientific|centos|fedora|owl|redhat|suse)
+                amazon|scientific|centos|almalinux|eurolinux|rocky|fedora|owl|redhat|suse)
                     echo "chkconfig '$name' on"
                 ;;
 

--- a/type/__svn/manifest
+++ b/type/__svn/manifest
@@ -28,7 +28,7 @@ state_should=$(cat "${__object:?}/parameter/state")
 
 case ${os}
 in
-	(alpine|archlinux|gentoo|debian|devuan|ubuntu|centos|fedora|scientific|suse|freebsd|openbsd)
+	(alpine|archlinux|gentoo|debian|devuan|ubuntu|centos|almalinux|eurolinux|rocky|fedora|scientific|suse|freebsd|openbsd)
 		if test "${state_should}" != 'absent'
 		then
 			__package subversion

--- a/type/__sysctl/gencode-remote
+++ b/type/__sysctl/gencode-remote
@@ -30,7 +30,7 @@ fi
 os=$(cat "$__global/explorer/os")
 case "$os" in
    # Linux
-   redhat|centos|ubuntu|debian|devuan|archlinux|gentoo|coreos)
+   redhat|centos|almalinux|eurolinux|rocky|ubuntu|debian|devuan|archlinux|gentoo|coreos)
       flag='-w'
       ;;
    # BusyBox

--- a/type/__sysctl/manifest
+++ b/type/__sysctl/manifest
@@ -25,7 +25,7 @@ os=$(cat "$__global/explorer/os")
 
 case "$os" in
    # Linux
-   alpine|redhat|centos|ubuntu|debian|devuan|archlinux|coreos)
+   alpine|redhat|centos|almalinux|eurolinux|rocky|ubuntu|debian|devuan|archlinux|coreos)
       :
    ;;
    # BSD

--- a/type/__unpack/gencode-remote
+++ b/type/__unpack/gencode-remote
@@ -35,7 +35,7 @@ case "$src" in
     ;;
     *.7z)
         case "$os" in
-            centos|fedora|redhat)
+            centos|almalinux|eurolinux|rocky|fedora|redhat)
                 cmd='7za'
             ;;
             *)

--- a/type/__unpack/manifest
+++ b/type/__unpack/manifest
@@ -23,7 +23,7 @@ case "$src" in
             debian|ubuntu|devuan)
                 __package xz-utils
             ;;
-            alpine|centos)
+            alpine|centos|almalinux|eurolinux|rocky)
                 __package xz
             ;;
         esac


### PR DESCRIPTION
This PR adds `os` definitions for the CentOS-descendants [AlmaLinux](http://almalinux.org), [Rocky Linux](http://rockylinux.org) and [EuroLinux](https://en.euro-linux.com).

I also updated the `case`s in all base types.
