### PR TITLE
Auto reformat man.rst

### DIFF
--- a/type/__acl/man.rst
+++ b/type/__acl/man.rst
@@ -8,13 +8,15 @@ cdist-type__acl - Set ACL entries
 
 DESCRIPTION
 -----------
-Fully supported and tested on Linux (ext4 filesystem), partial support for FreeBSD.
+Fully supported and tested on Linux (ext4 filesystem), partial support for
+FreeBSD.
 
-See ``setfacl`` and ``acl`` manpages for more details.
+See :strong:`setfacl`\ (1) and :strong:`acl`\ (5) man pages for more details.
 
 One of ``--entry`` or ``--source`` must be used.
 
-There's special case with (capital) ``X`` perms bit - when used, ``x`` bit is set only for directories.
+There's special case with (capital) ``X`` perms bit - when used, ``x`` bit is
+set only for directories.
 
 
 OPTIONAL MULTIPLE PARAMETERS
@@ -26,17 +28,16 @@ entry
 
 OPTIONAL PARAMETERS
 -------------------
+directory
+   Create/change directory with ``__directory`` using ``user:group:mode``
+   pattern.
+file
+   Create/change file with ``__file`` using ``user:group:mode`` pattern.
 source
    Read ACL entries from stdin or file.
    Ordering of entries is not important.
    When reading from file, comments and empty lines are ignored.
    Must be used if ``--entry`` is not used.
-
-file
-   Create/change file with ``__file`` using ``user:group:mode`` pattern.
-
-directory
-   Create/change directory with ``__directory`` using ``user:group:mode`` pattern.
 
 
 BOOLEAN PARAMETERS
@@ -45,10 +46,8 @@ default
    Set all ACL entries as default too.
    Only directories can have default ACLs.
    Setting default ACL in FreeBSD is currently not supported.
-
 recursive
    Make ``setfacl`` recursive (Linux only), but not ``getfacl`` in explorer.
-
 remove
    Remove undefined ACL entries.
    ``mask`` and ``other`` entries can't be removed, but only changed.
@@ -59,52 +58,52 @@ EXAMPLES
 
 .. code-block:: sh
 
-    __acl /srv/project \
-        --default \
-        --recursive \
-        --remove \
-        --entry user:alice:rwx \
-        --entry user:bob:r-x \
-        --entry group:project-group:rwx \
-        --entry group:some-other-group:r-x \
-        --entry mask::r-x \
-        --entry other::r-x
+   __acl /srv/project \
+       --default \
+       --recursive \
+       --remove \
+       --entry user:alice:rwx \
+       --entry user:bob:r-x \
+       --entry group:project-group:rwx \
+       --entry group:some-other-group:r-x \
+       --entry mask::r-x \
+       --entry other::r-x
 
-    # give Alice read-only access to subdir,
-    # but don't allow her to see parent content.
+   # give Alice read-only access to subdir,
+   # but don't allow her to see parent content.
 
-    __acl /srv/project2 \
-        --remove \
-        --entry default:group:secret-project:rwx \
-        --entry group:secret-project:rwx \
-        --entry user:alice:--x
+   __acl /srv/project2 \
+       --remove \
+       --entry default:group:secret-project:rwx \
+       --entry group:secret-project:rwx \
+       --entry user:alice:--x
 
-    __acl /srv/project2/subdir \
-        --default \
-        --remove \
-        --entry group:secret-project:rwx \
-        --entry user:alice:r-x
+   __acl /srv/project2/subdir \
+       --default \
+       --remove \
+       --entry group:secret-project:rwx \
+       --entry user:alice:r-x
 
-    # read acl from stdin
-    echo 'user:alice:rwx' \
-        | __acl /path/to/directory --source -
+   # read acl from stdin
+   echo 'user:alice:rwx' \
+       | __acl /path/to/directory --source -
 
-    # create/change directory too
-    __acl /path/to/directory \
-        --default \
-        --remove \
-        --directory root:root:770 \
-        --entry user:nobody:rwx
+   # create/change directory too
+   __acl /path/to/directory \
+       --default \
+       --remove \
+       --directory root:root:770 \
+       --entry user:nobody:rwx
 
 
 AUTHORS
 -------
-Ander Punnar <ander-at-kvlt-dot-ee>
+* Ander Punnar <ander-at-kvlt-dot-ee>
 
 
 COPYING
 -------
-Copyright \(C) 2018 Ander Punnar. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2018 Ander Punnar.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__apt_backports/man.rst
+++ b/type/__apt_backports/man.rst
@@ -8,24 +8,18 @@ cdist-type__apt_backports - Configure the backports APT repository
 
 DESCRIPTION
 -----------
-
 This singleton type manages the backports repository for the current OS
 release and updates the package index if required.
 
 It supports backports for the following OSes:
 
-- Debian
-- Devuan
-- Ubuntu
+* Debian
+* Devuan
+* Ubuntu
 
-NB: The type aborts if no distribuition codename could be detected. This is
+**NB:** The type aborts if no distribuition codename could be detected. This is
 common for unstable releases, but there is no backports repository for these
 anyway.
-
-
-REQUIRED PARAMETERS
--------------------
-None.
 
 
 OPTIONAL PARAMETERS
@@ -36,27 +30,15 @@ component
    Can be used multiple times to specify more than one component.
 
    Defaults to: ``main``
+mirror
+   The mirror to fetch the backports from.
 
+   Defaults to the generic mirror of the current OS.
 state
    The should state of the backports repository. ``present`` or
    ``absent``.
 
    Defaults to: ``present``
-
-mirror
-   The mirror to fetch the backports from.
-
-   Defaults to the generic mirror of the current OS.
-
-
-BOOLEAN PARAMETERS
-------------------
-None.
-
-
-MESSAGES
---------
-None.
 
 
 EXAMPLES
@@ -77,14 +59,14 @@ EXAMPLES
 
 SEE ALSO
 --------
-- `Official Debian Backports site <https://backports.debian.org/>`_
-- :strong:`cdist-type__apt_source`\ (7)
+* `Official Debian Backports site <https://backports.debian.org/>`_
+* :strong:`cdist-type__apt_source`\ (7)
 
 
 AUTHORS
 -------
-Matthias Stecher <matthiasstecher--@--gmx.de>,
-Dennis Camera <cdist--@--dtnr.ch>
+* Matthias Stecher <matthiasstecher--@--gmx.de>
+* Dennis Camera <cdist--@--dtnr.ch>
 
 
 COPYING

--- a/type/__apt_default_release/man.rst
+++ b/type/__apt_default_release/man.rst
@@ -11,6 +11,7 @@ DESCRIPTION
 Configure the default release for apt, using the APT::Default-Release
 configuration value.
 
+
 REQUIRED PARAMETERS
 -------------------
 release
@@ -20,27 +21,22 @@ release
    'stable', 'testing', 'unstable', 'stretch', 'buster', '4.0', '5.0*'.
 
 
-OPTIONAL PARAMETERS
--------------------
-None.
-
-
 EXAMPLES
 --------
 
 .. code-block:: sh
 
-    __apt_default_release --release stretch
+   __apt_default_release --release stretch
 
 
 AUTHORS
 -------
-Matthijs Kooijman <matthijs--@--stdin.nl>
+* Matthijs Kooijman <matthijs--@--stdin.nl>
 
 
 COPYING
 -------
-Copyright \(C) 2017 Matthijs Kooijman. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2017 Matthijs Kooijman.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__apt_key/man.rst
+++ b/type/__apt_key/man.rst
@@ -19,45 +19,24 @@ In order of preference, exactly one of: ``source``, ``uri`` or ``keyid``
 must be specified.
 
 
-REQUIRED PARAMETERS
--------------------
-None.
-
-
 OPTIONAL PARAMETERS
 -------------------
 keydir
    keyring directory, defaults to ``/etc/apt/trusted.pgp.d``, which is
    enabled system-wide by default.
-
 source
    path to a file containing the GPG key of the repository.
    Using this is recommended as it ensures that the manifest/type manintainer
    has validated the key.
    If ``-``, the GPG key is read from the type's stdin.
-
 state
    'present' or 'absent'. Defaults to 'present'
-
 uri
    the URI from which to download the key.
    It is highly recommended that you only use protocols with TLS like HTTPS.
    This uses ``__download`` but does not use checksums, if you want to ensure
    that the key doesn't change, you are better off downloading it and using
    ``--source``.
-
-
-DEPRECATED OPTIONAL PARAMETERS
-------------------------------
-keyid
-   the id of the key to download from the ``keyserver``.
-   This is to be used in absence of ``--source`` and ``--uri`` or together
-   with ``--use-deprecated-apt-key`` for key removal.
-   Defaults to ``$__object_id``.
-
-keyserver
-   the keyserver from which to fetch the key.
-   Defaults to ``pool.sks-keyservers.net``.
 
 
 DEPRECATED BOOLEAN PARAMETERS
@@ -71,44 +50,56 @@ use-deprecated-apt-key
    This parameter will be removed when Debian 11 stops being supported.
 
 
+DEPRECATED OPTIONAL PARAMETERS
+------------------------------
+keyid
+   the id of the key to download from the ``keyserver``.
+   This is to be used in absence of ``--source`` and ``--uri`` or together
+   with ``--use-deprecated-apt-key`` for key removal.
+   Defaults to ``$__object_id``.
+keyserver
+   the keyserver from which to fetch the key.
+   Defaults to ``pool.sks-keyservers.net``.
+
+
 EXAMPLES
 --------
 
 .. code-block:: sh
 
-    # add a key that has been verified by a type maintainer
-    __apt_key jitsi_meet_2021 \
-       --source cdist-contrib/type/__jitsi_meet/files/apt_2021.gpg
+   # add a key that has been verified by a type maintainer
+   __apt_key jitsi_meet_2021 \
+      --source cdist-contrib/type/__jitsi_meet/files/apt_2021.gpg
 
-    # remove an old, deprecated or expired key
-    __apt_key jitsi_meet_2016 --state absent
+   # remove an old, deprecated or expired key
+   __apt_key jitsi_meet_2016 --state absent
 
-    # Get rid of a key that might have been added to
-    # /etc/apt/trusted.gpg with apt-key
-    __apt_key 0x40976EAF437D05B5 --use-deprecated-apt-key --state absent
+   # Get rid of a key that might have been added to
+   # /etc/apt/trusted.gpg with apt-key
+   __apt_key 0x40976EAF437D05B5 --use-deprecated-apt-key --state absent
 
-    # add a key that we define in-line
-    __apt_key jitsi_meet_2021 --source '-' <<EOF
-    -----BEGIN PGP PUBLIC KEY BLOCK-----
-    [...]
-    -----END PGP PUBLIC KEY BLOCK-----
-    EOF
+   # add a key that we define in-line
+   __apt_key jitsi_meet_2021 --source '-' <<EOF
+   -----BEGIN PGP PUBLIC KEY BLOCK-----
+   [...]
+   -----END PGP PUBLIC KEY BLOCK-----
+   EOF
 
-    # download or update key from the internet
-    __apt_key rabbitmq_2007 \
-       --uri https://www.rabbitmq.com/rabbitmq-signing-key-public.asc
+   # download or update key from the internet
+   __apt_key rabbitmq_2007 \
+      --uri https://www.rabbitmq.com/rabbitmq-signing-key-public.asc
 
 
 AUTHORS
 -------
-Steven Armstrong <steven-cdist--@--armstrong.cc>
-Ander Punnar <ander-at-kvlt-dot-ee>
-Evilham <contact~~@~~evilham.com>
+* Steven Armstrong <steven-cdist--@--armstrong.cc>
+* Ander Punnar <ander-at-kvlt-dot-ee>
+* Evilham <contact~~@~~evilham.com>
 
 
 COPYING
 -------
-Copyright \(C) 2011-2021 Steven Armstrong, Ander Punnar and Evilham. You can
-redistribute it and/or modify it under the terms of the GNU General Public
-License as published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2011-2021 Steven Armstrong, Ander Punnar and Evilham.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__apt_key_uri/man.rst
+++ b/type/__apt_key_uri/man.rst
@@ -19,12 +19,14 @@ uri
 
 OPTIONAL PARAMETERS
 -------------------
-state
-   'present' or 'absent', defaults to 'present'
-
 name
    a name for this key, used when testing if it is already installed.
-   Defaults to __object_id
+
+   Defaults to: ``__object_id``
+state
+   ``present`` or ``absent``
+
+   Defaults to: ``present``
 
 
 EXAMPLES
@@ -32,20 +34,20 @@ EXAMPLES
 
 .. code-block:: sh
 
-    __apt_key_uri rabbitmq \
-       --name 'RabbitMQ Release Signing Key <info@rabbitmq.com>' \
-       --uri http://www.rabbitmq.com/rabbitmq-signing-key-public.asc \
-       --state present
+   __apt_key_uri rabbitmq \
+      --name 'RabbitMQ Release Signing Key <info@rabbitmq.com>' \
+      --uri http://www.rabbitmq.com/rabbitmq-signing-key-public.asc \
+      --state present
 
 
 AUTHORS
 -------
-Steven Armstrong <steven-cdist--@--armstrong.cc>
+* Steven Armstrong <steven-cdist--@--armstrong.cc>
 
 
 COPYING
 -------
-Copyright \(C) 2011-2014 Steven Armstrong. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2011-2014 Steven Armstrong.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__apt_mark/man.rst
+++ b/type/__apt_mark/man.rst
@@ -28,20 +28,20 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # hold package
-    __apt_mark quagga --state hold
-    # unhold package
-    __apt_mark quagga --state unhold
+   # hold package
+   __apt_mark quagga --state hold
+   # unhold package
+   __apt_mark quagga --state unhold
 
 
 AUTHORS
 -------
-Ander Punnar <cdist--@--kvlt.ee>
+* Ander Punnar <cdist--@--kvlt.ee>
 
 
 COPYING
 -------
-Copyright \(C) 2016 Ander Punnar. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2016 Ander Punnar.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__apt_norecommends/man.rst
+++ b/type/__apt_norecommends/man.rst
@@ -11,28 +11,18 @@ DESCRIPTION
 Configure apt to not install any recommended or suggested packages.
 
 
-REQUIRED PARAMETERS
--------------------
-None.
-
-
-OPTIONAL PARAMETERS
--------------------
-None.
-
-
 EXAMPLES
 --------
 
 .. code-block:: sh
 
-    __apt_norecommends
+   __apt_norecommends
 
 
 AUTHORS
 -------
-Steven Armstrong <steven-cdist--@--armstrong.cc>
-Dennis Camera <dennis.camera--@--ssrq-sds-fds.ch>
+* Steven Armstrong <steven-cdist--@--armstrong.cc>
+* Dennis Camera <dennis.camera--@--ssrq-sds-fds.ch>
 
 
 COPYING

--- a/type/__apt_pin/man.rst
+++ b/type/__apt_pin/man.rst
@@ -8,31 +8,32 @@ cdist-type__apt_pin - Manage apt pinning rules
 
 DESCRIPTION
 -----------
-Adds/removes/edits rules to pin some packages to a specific distribution. Useful if using multiple debian repositories at the same time. (Useful, if one wants to use a few specific packages from backports or perhaps Debain testing... or even sid.)
+Adds/removes/edits rules to pin some packages to a specific distribution. Useful
+if using multiple debian repositories at the same time. (Useful, if one wants to
+use a few specific packages from backports or perhaps Debain testing... or even
+sid.)
 
 
 REQUIRED PARAMETERS
 -------------------
 distribution
-   Specifies what distribution the package should be pinned to. Accepts both codenames (buster/bullseye/sid) and suite names (stable/testing/...).
+   Specifies what distribution the package should be pinned to. Accepts both
+   codenames (buster/bullseye/sid) and suite names (stable/testing/...).
 
 
 OPTIONAL PARAMETERS
 -------------------
 package
-   Package name, glob or regular expression to match (multiple) packages. If not specified `__object_id` is used.
+   Package name, glob or regular expression to match (multiple) packages.
 
+   Defaults to: ``__objet_id``
 priority
-   The priority value to assign to matching packages. Deafults to 500. (To match the default target distro's priority)
+   The priority value to assign to matching packages.
 
+   Defaults to: 500 (to match the default target distro's priority)
 state
-   Will be passed to underlying `__file` type; see there for valid values and defaults.
-
-
-
-BOOLEAN PARAMETERS
-------------------
-None.
+   Will be passed to underlying ``__file`` type; see there for valid values and
+   defaults.
 
 
 EXAMPLES
@@ -40,40 +41,44 @@ EXAMPLES
 
 .. code-block:: sh
 
-   # Add the bullseye repo to buster, but do not install any packages by default,
-   # only if explicitely asked for (-1 means "never" for apt)
-    __apt_pin bullseye-default \
-       --package "*" \
-       --distribution bullseye \
-       --priority -1
+   # Add the bullseye repo to buster, but do not install any packages by default
+   # only if explicitly asked for (-1 means "never" for apt)
+   __apt_pin bullseye-default \
+      --package '*' \
+      --distribution bullseye \
+      --priority -1
 
-    require="__apt_pin/bullseye-default" __apt_source bullseye \
-       --uri http://deb.debian.org/debian/ \
-       --distribution bullseye \
-       --component main
+   require=__apt_pin/bullseye-default \
+   __apt_source bullseye \
+      --uri http://deb.debian.org/debian/ \
+      --distribution bullseye \
+      --component main
 
-    __apt_pin foo --package "foo foo-*" --distribution bullseye
+   __apt_pin foo \
+      --package "foo foo-*" \
+      --distribution bullseye
 
-    __foo # Assuming, this installs the `foo` package internally
+    __foo  # assuming, this installs the `foo` package internally
 
-    __package foo-plugin-extras # Assuming we also need some extra stuff
+    __package foo-plugin-extras  # assuming we also need some extra stuff
 
 
 SEE ALSO
 --------
-:strong:`apt_preferences`\ (5)
-:strong:`cdist-type__apt_source`\ (7)
-:strong:`cdist-type__apt_backports`\ (7)
-:strong:`cdist-type__file`\ (7)
+* :strong:`apt_preferences`\ (5)
+* :strong:`cdist-type__apt_source`\ (7)
+* :strong:`cdist-type__apt_backports`\ (7)
+* :strong:`cdist-type__file`\ (7)
+
 
 AUTHORS
 -------
-Daniel Fancsali <fancsali@gmail.com>
+* Daniel Fancsali <fancsali@gmail.com>
 
 
 COPYING
 -------
-Copyright \(C) 2021 Daniel Fancsali. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2021 Daniel Fancsali.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__apt_ppa/man.rst
+++ b/type/__apt_ppa/man.rst
@@ -18,33 +18,28 @@ state
    Defaults to 'present'
 
 
-OPTIONAL PARAMETERS
--------------------
-None.
-
-
 EXAMPLES
 --------
 
 .. code-block:: sh
 
-    # Enable a ppa repository
-    __apt_ppa ppa:sans-intern/missing-bits
-    # same as
-    __apt_ppa ppa:sans-intern/missing-bits --state present
+   # Enable a ppa repository
+   __apt_ppa ppa:sans-intern/missing-bits
+   # same as
+   __apt_ppa ppa:sans-intern/missing-bits --state present
 
-    # Disable a ppa repository
-    __apt_ppa ppa:sans-intern/missing-bits --state absent
+   # Disable a ppa repository
+   __apt_ppa ppa:sans-intern/missing-bits --state absent
 
 
 AUTHORS
 -------
-Steven Armstrong <steven-cdist--@--armstrong.cc>
+* Steven Armstrong <steven-cdist--@--armstrong.cc>
 
 
 COPYING
 -------
-Copyright \(C) 2011-2014 Steven Armstrong. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2011-2014 Steven Armstrong.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__apt_source/man.rst
+++ b/type/__apt_source/man.rst
@@ -18,26 +18,25 @@ uri
    the uri to the apt repository
 
 
-OPTIONAL PARAMETERS
--------------------
-arch
-   set this if you need to force and specific arch (ubuntu specific)
-
-state
-   'present' or 'absent', defaults to 'present'
-
-distribution
-   the distribution codename to use. Defaults to DISTRIB_CODENAME from
-   the targets /etc/lsb-release
-
-component
-   space delimited list of components to enable. Defaults to an empty string.
-
-
 OPTIONAL MULTIPLE PARAMETERS
 ----------------------------
 signed-by
    provide a GPG key fingerprint or keyring path for signature checks.
+
+
+OPTIONAL PARAMETERS
+-------------------
+arch
+   set this if you need to force and specific arch (ubuntu specific)
+component
+   space delimited list of components to enable. Defaults to an empty string.
+distribution
+   the distribution codename to use. Defaults to DISTRIB_CODENAME from
+   the targets /etc/lsb-release
+state
+   ``present`` or ``absent``
+
+   Defaults to: ``present``
 
 
 BOOLEAN PARAMETERS
@@ -51,32 +50,32 @@ EXAMPLES
 
 .. code-block:: sh
 
-    __apt_source rabbitmq \
-       --uri http://www.rabbitmq.com/debian/ \
-       --distribution testing \
-       --component main \
-       --include-src \
-       --state present
+   __apt_source rabbitmq \
+      --uri http://www.rabbitmq.com/debian/ \
+      --distribution testing \
+      --component main \
+      --include-src \
+      --state present
 
-    __apt_source canonical_partner \
-       --uri http://archive.canonical.com/ \
-       --component partner --state present
+   __apt_source canonical_partner \
+      --uri http://archive.canonical.com/ \
+      --component partner --state present
 
-    __apt_source goaccess \
-       --uri http://deb.goaccess.io/ \
-       --component main \
-       --signed-by C03B48887D5E56B046715D3297BD1A0133449C3D
+   __apt_source goaccess \
+      --uri http://deb.goaccess.io/ \
+      --component main \
+      --signed-by C03B48887D5E56B046715D3297BD1A0133449C3D
 
 
 AUTHORS
 -------
-Steven Armstrong <steven-cdist--@--armstrong.cc>
-Daniel Fancsali <fancsali--@--gmail.com>
+* Steven Armstrong <steven-cdist--@--armstrong.cc>
+* Daniel Fancsali <fancsali--@--gmail.com>
 
 
 COPYING
 -------
-Copyright \(C) 2011-2018 Steven Armstrong. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2011-2018 Steven Armstrong.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__apt_unattended_upgrades/man.rst
+++ b/type/__apt_unattended_upgrades/man.rst
@@ -8,7 +8,6 @@ cdist-type__apt_unattended_upgrades - automatic installation of updates
 
 DESCRIPTION
 -----------
-
 Install and configure unattended-upgrades package.
 
 For more information see https://wiki.debian.org/UnattendedUpgrades.
@@ -16,31 +15,30 @@ For more information see https://wiki.debian.org/UnattendedUpgrades.
 
 OPTIONAL MULTIPLE PARAMETERS
 ----------------------------
+blacklist
+   Python regular expressions, matching packages to exclude from upgrading.
 option
    Set options for unattended-upgrades. See examples.
 
    Supported options with default values (as of 2020-01-17) are:
 
-   - AutoFixInterruptedDpkg, default is "true"
-   - MinimalSteps, default is "true"
-   - InstallOnShutdown, default is "false"
-   - Mail, default is "" (empty)
-   - MailOnlyOnError, default is "false"
-   - Remove-Unused-Kernel-Packages, default is "true"
-   - Remove-New-Unused-Dependencies, default is "true"
-   - Remove-Unused-Dependencies, default is "false"
-   - Automatic-Reboot, default is "false"
-   - Automatic-Reboot-WithUsers, default is "true"
-   - Automatic-Reboot-Time, default is "02:00"
-   - SyslogEnable, default is "false"
-   - SyslogFacility, default is "daemon"
-   - OnlyOnACPower, default is "true"
-   - Skip-Updates-On-Metered-Connections, default is "true"
-   - Verbose, default is "false"
-   - Debug, default is "false"
-
-blacklist
-   Python regular expressions, matching packages to exclude from upgrading.
+   * AutoFixInterruptedDpkg, default is "true"
+   * MinimalSteps, default is "true"
+   * InstallOnShutdown, default is "false"
+   * Mail, default is "" (empty)
+   * MailOnlyOnError, default is "false"
+   * Remove-Unused-Kernel-Packages, default is "true"
+   * Remove-New-Unused-Dependencies, default is "true"
+   * Remove-Unused-Dependencies, default is "false"
+   * Automatic-Reboot, default is "false"
+   * Automatic-Reboot-WithUsers, default is "true"
+   * Automatic-Reboot-Time, default is "02:00"
+   * SyslogEnable, default is "false"
+   * SyslogFacility, default is "daemon"
+   * OnlyOnACPower, default is "true"
+   * Skip-Updates-On-Metered-Connections, default is "true"
+   * Verbose, default is "false"
+   * Debug, default is "false"
 
 
 EXAMPLES
@@ -48,21 +46,21 @@ EXAMPLES
 
 .. code-block:: sh
 
-    __apt_unattended_upgrades \
-        --option Mail=root \
-        --option MailOnlyOnError=true \
-        --blacklist multipath-tools \
-        --blacklist open-iscsi
+   __apt_unattended_upgrades \
+       --option Mail=root \
+       --option MailOnlyOnError=true \
+       --blacklist multipath-tools \
+       --blacklist open-iscsi
 
 
 AUTHORS
 -------
-Ander Punnar <ander-at-kvlt-dot-ee>
+* Ander Punnar <ander-at-kvlt-dot-ee>
 
 
 COPYING
 -------
-Copyright \(C) 2020 Ander Punnar. You can redistribute it and/or modify it
-under the terms of the GNU General Public License as published by the Free
-Software Foundation, either version 3 of the License, or (at your option) any
-later version.
+Copyright \(C) 2020 Ander Punnar.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__apt_update_index/man.rst
+++ b/type/__apt_update_index/man.rst
@@ -10,22 +10,26 @@ DESCRIPTION
 -----------
 This type will update APT package index if any of following is true:
 
-- ``/var/lib/apt/lists`` is missing.
-- ``/etc/apt/`` content is newer than ``/var/lib/apt/lists/`` (type will ``touch`` it after every update).
-- Package index cache is missing or older than ``--maxage``.
-- ``--always`` parameter is set.
+* ``/var/lib/apt/lists`` is missing.
+* ``/etc/apt/`` content is newer than ``/var/lib/apt/lists/`` (type will
+  :strong:`touch`\ (1) it after every update).
+* Package index cache is missing or older than ``--maxage``.
+* ``--always`` parameter is set.
 
 
 OPTIONAL PARAMETERS
 -------------------
 maxage
-    Update is skipped if maximum age (in seconds) of package index cache is not reached yet. Defaults to 86400.
+   Update is skipped if maximum age (in seconds) of package index cache is not
+   reached yet.
+
+   Defaults to: 86400
 
 
 BOOLEAN PARAMETERS
 ------------------
 always
-    Always update package index.
+   Always update package index.
 
 
 EXAMPLES
@@ -33,22 +37,22 @@ EXAMPLES
 
 .. code-block:: sh
 
-    __apt_update_index
+   __apt_update_index
 
 
 SEE ALSO
 --------
-:strong:`cdist-type__package_apt`\ (7)
+* :strong:`cdist-type__package_apt`\ (7)
 
 
 AUTHORS
 -------
-Steven Armstrong <steven-cdist--@--armstrong.cc>
+* Steven Armstrong <steven-cdist--@--armstrong.cc>
 
 
 COPYING
 -------
-Copyright \(C) 2011 Steven Armstrong. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2011 Steven Armstrong.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__block/man.rst
+++ b/type/__block/man.rst
@@ -26,17 +26,16 @@ OPTIONAL PARAMETERS
 file
    the file in which to manage the text block.
    Defaults to object_id.
-
 prefix
    the prefix to add before the text.
    Defaults to #cdist:__block/$__object_id
+state
+   ``present`` or ``absent``
 
+   Defaults to: ``present``
 suffix
    the suffix to add after the text.
    Defaults to #/cdist:__block/$__object_id
-
-state
-   'present' or 'absent', defaults to 'present'
 
 
 MESSAGES
@@ -54,29 +53,29 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # text from argument
-    __block /path/to/file \
-       --prefix '#start' \
-       --suffix '#end' \
-       --text 'some\nblock of\ntext'
+   # text from argument
+   __block /path/to/file \
+      --prefix '#start' \
+      --suffix '#end' \
+      --text 'some\nblock of\ntext'
 
-    # text from stdin
-    __block some-id \
-       --file /path/to/file \
-       --text - << DONE
-    here some block
-    of text
-    DONE
+   # text from stdin
+   __block some-id \
+      --file /path/to/file \
+      --text - <<'EOF'
+   here some block
+   of text
+   EOF
 
 
 AUTHORS
 -------
-Steven Armstrong <steven-cdist--@--armstrong.cc>
+* Steven Armstrong <steven-cdist--@--armstrong.cc>
 
 
 COPYING
 -------
-Copyright \(C) 2013 Steven Armstrong. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2013 Steven Armstrong.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__cdistmarker/man.rst
+++ b/type/__cdistmarker/man.rst
@@ -14,20 +14,14 @@ timestamp, which can be used to determine the most recent time at which cdist
 was run against the machine in question.
 
 
-REQUIRED PARAMETERS
--------------------
-None.
-
-
 OPTIONAL PARAMETERS
 -------------------
 destination
-    The path and filename of the marker.
-    Default: /etc/cdist-configured
-
+   The path and filename of the marker.
+   Default: /etc/cdist-configured
 format
-    The format of the timestamp. This is passed directly to system 'date'.
-    Default: -u
+   The format of the timestamp. This is passed directly to system 'date'.
+   Default: -u
 
 
 EXAMPLES
@@ -35,21 +29,21 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Creates the marker as normal.
-    __cdistmarker
+   # Creates the marker as normal.
+   __cdistmarker
 
-    # Creates the marker differently.
-    __cdistmarker --destination /tmp/cdist_marker --format '+%s'
+   # Creates the marker differently.
+   __cdistmarker --destination /tmp/cdist_marker --format '+%s'
 
 
 AUTHORS
 -------
-Daniel Maher <phrawzty+cdist--@--gmail.com>
+* Daniel Maher <phrawzty+cdist--@--gmail.com>
 
 
 COPYING
 -------
-Copyright \(C) 2011 Daniel Maher. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2011 Daniel Maher.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__check_messages/man.rst
+++ b/type/__check_messages/man.rst
@@ -3,7 +3,8 @@ cdist-type__check_messages(7)
 
 NAME
 ----
-cdist-type__check_messages - Check messages for pattern and execute command on match.
+cdist-type__check_messages - Check messages for pattern and execute command on
+match.
 
 
 DESCRIPTION
@@ -14,19 +15,18 @@ This type is useful if you chain together multiple related types using
 dependencies and want to restart service if at least one type changes
 something.
 
-For more information about messages see `cdist messaging <cdist-messaging.html>`_.
+For more information about messages see `messaging <cdist-messaging.html>`_.
 
 For more information about dependencies and execution order see
-`cdist manifest <cdist-manifest.html#dependencies>`_ documentation.
+`manifest <cdist-manifest.html#dependencies>`_ documentation.
 
 
 REQUIRED PARAMETERS
 -------------------
-pattern
-   Extended regular expression pattern for search (passed to ``grep -E``).
-
 execute
    Command to execute on pattern match.
+pattern
+   Extended regular expression pattern for search (passed to ``grep -E``).
 
 
 EXAMPLES
@@ -34,19 +34,19 @@ EXAMPLES
 
 .. code-block:: sh
 
-    __check_messages munin \
-        --pattern '^__(file|link|line)/etc/munin/' \
-        --execute 'service munin-node restart'
+   __check_messages munin \
+      --pattern '^__(file|link|line)/etc/munin/' \
+      --execute 'service munin-node restart'
 
 
 AUTHORS
 -------
-Ander Punnar <ander-at-kvlt-dot-ee>
+* Ander Punnar <ander-at-kvlt-dot-ee>
 
 
 COPYING
 -------
-Copyright \(C) 2019 Ander Punnar. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2019 Ander Punnar.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__clean_path/man.rst
+++ b/type/__clean_path/man.rst
@@ -29,14 +29,12 @@ pattern
 
 OPTIONAL PARAMETERS
 -------------------
-path
-   Path which will be cleaned. Defaults to ``$__object_id``.
-
 exclude
    Pattern of files which are excluded from removal.
-
 onchange
    The code to run if files or directories were removed.
+path
+   Path which will be cleaned. Defaults to ``$__object_id``.
 
 
 EXAMPLES
@@ -44,25 +42,26 @@ EXAMPLES
 
 .. code-block:: sh
 
-    __clean_path /etc/apache2/conf-enabled \
-        --pattern '.+' \
-        --exclude '.+\(charset\.conf\|security\.conf\)' \
-        --onchange 'service apache2 restart'
+   __clean_path /etc/apache2/conf-enabled \
+       --pattern '.+' \
+       --exclude '.+\(charset\.conf\|security\.conf\)' \
+       --onchange 'service apache2 restart'
 
-    __clean_path apache2-conf-enabled \
-        --path /etc/apache2/conf-enabled \
-        --pattern '.+' \
-        --exclude '.+\(charset\.conf\|security\.conf\)' \
-        --onchange 'service apache2 restart'
+   __clean_path apache2-conf-enabled \
+       --path /etc/apache2/conf-enabled \
+       --pattern '.+' \
+       --exclude '.+\(charset\.conf\|security\.conf\)' \
+       --onchange 'service apache2 restart'
+
 
 AUTHORS
 -------
-Ander Punnar <ander-at-kvlt-dot-ee>
+* Ander Punnar <ander-at-kvlt-dot-ee>
 
 
 COPYING
 -------
-Copyright \(C) 2019 Ander Punnar. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2019 Ander Punnar.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__cron/man.rst
+++ b/type/__cron/man.rst
@@ -13,8 +13,6 @@ This cdist type allows you to manage entries in a user's crontab.
 
 REQUIRED PARAMETERS
 -------------------
-user
-   The user whose crontab is edited.
 command
    The command to run.
 
@@ -23,28 +21,32 @@ command
    characters.
    This type will not do any % replacements. The command given will be passed
    literally into the crontab file.
+user
+   The user whose crontab is edited.
 
 
 OPTIONAL PARAMETERS
 -------------------
-**NOTE**: All time-related parameters (``--minute``, ``--hour``,
-``--day-of-month``, ``--month`` and ``--day-of-week``) default to ``*``
-which means to execute it **always**.
-If you set ``--hour 0`` to execute the cronjob only at midnight, it
-will execute **every** minute in the first hour of the morning every day.
-
-state
-   Either present or absent. Defaults to present.
-minute
-   See crontab(5). Defaults to *
-hour
-   See crontab(5). Defaults to *
 day-of-month
-   See crontab(5). Defaults to *
-month
-   See crontab(5). Defaults to *
+   See :strong:`crontab`\ (5).
+
+   Defaults to: ``*`` (i.e. "always")
 day-of-week
-   See crontab(5). Defaults to *
+   See :strong:`crontab`\ (5).
+
+   Defaults to: ``*`` (i.e. "always")
+hour
+   See :strong:`crontab`\ (5).
+
+   Defaults to: ``*`` (i.e. "always")
+minute
+   See :strong:`crontab`\ (5).
+
+   Defaults to: ``*`` (i.e. "always")
+month
+   See :strong:`crontab`\ (5).
+
+   Defaults to: ``*`` (i.e. "always")
 raw
    Take whatever the user has given instead of time and date fields.
    If given, all other time and date fields are ignored.
@@ -52,6 +54,15 @@ raw
    ``@yearly``, etc.
    See :strong:`crontab`\ (5) for the extensions if any that your cron
    implementation implements.
+state
+   One of:
+
+   present
+      the cron job is defined
+   absent
+      the cron job is not defined
+
+   Defaults to: ``present``
 
 
 EXAMPLES
@@ -59,16 +70,23 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # run Monday to Saturday at 23:15
-    __cron some-id --user root --command "/path/to/script" \
-       --hour 23 --minute 15 --day-of-week 1-6
+   # run Monday to Saturday at 23:15
+   __cron some-id \
+      --user root \
+      --command "/path/to/script" \
+      --hour 23 --minute 15 --day-of-week 1-6
 
-    # run on reboot
-    __cron some-id --user root --command "/path/to/script" \
-       --raw @reboot
+   # run on reboot
+   __cron some-id \
+      --user root
+      --command "/path/to/script" \
+      --raw @reboot
 
-    # remove cronjob
-    __cron some-id --user root --command "/path/to/script" --state absent
+   # remove cronjob
+   __cron some-id \
+      --user root \
+      --command "/path/to/script" \
+      --state absent
 
 
 SEE ALSO
@@ -79,8 +97,8 @@ SEE ALSO
 
 AUTHORS
 -------
-| Steven Armstrong <steven-cdist--@--armstrong.cc>
-| Dennis Camera <cdist--@--dtnr.ch>
+* Steven Armstrong <steven-cdist--@--armstrong.cc>
+* Dennis Camera <cdist--@--dtnr.ch>
 
 
 COPYING

--- a/type/__cron_env/man.rst
+++ b/type/__cron_env/man.rst
@@ -36,10 +36,6 @@ name
    The name of the variable to configure.
 
    Defaults to: ``__object_id``
-value
-   The value of the variable.
-
-   Required if ``--state present``.
 state
    One of:
 
@@ -47,11 +43,10 @@ state
       the variable should be set to the given value
    ``absent``
       the variable should be removed
+value
+   The value of the variable.
 
-
-BOOLEAN PARAMETERS
-------------------
-None.
+   Required if ``--state present``.
 
 
 EXAMPLES
@@ -74,7 +69,7 @@ SEE ALSO
 
 AUTHORS
 -------
-Dennis Camera <cdist--@--dtnr.ch>
+* Dennis Camera <cdist--@--dtnr.ch>
 
 
 COPYING

--- a/type/__debconf_set_selections/man.rst
+++ b/type/__debconf_set_selections/man.rst
@@ -12,18 +12,14 @@ On Debian and alike systems :strong:`debconf-set-selections`\ (1) can be used
 to setup configuration parameters.
 
 
-REQUIRED PARAMETERS
--------------------
-cf. ``--line``.
-
-
 OPTIONAL PARAMETERS
 -------------------
 file
    Use the given filename as input for :strong:`debconf-set-selections`\ (1)
    If filename is ``-``, read from stdin.
 
-   **This parameter is deprecated, because it doesn't work with state detection.**
+   **This parameter is deprecated, because it doesn't work with state
+   detection.**
 line
    A line in :strong:`debconf-set-selections`\ (1) compatible format.
    This parameter can be used multiple times to set multiple options.
@@ -46,30 +42,33 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Setup gitolite's gituser
-    __debconf_set_selections nslcd --line 'gitolite gitolite/gituser string git'
+   # Setup gitolite's gituser
+   __debconf_set_selections nslcd \
+      --line 'gitolite gitolite/gituser string git'
 
-    # Setup configuration for nslcd from a file.
-    # NB: Multiple lines can be passed to --line, although this can be considered a hack.
-    __debconf_set_selections nslcd --line "$(cat "${__files:?}/preseed/nslcd.debconf")"
+   # Setup configuration for nslcd from a file.
+   # NB: Multiple lines can be passed to --line, although this can be considered
+   #     a hack.
+   __debconf_set_selections nslcd \
+      --line "$(cat "${__files:?}/preseed/nslcd.debconf")"
 
-    # Reconfigure wireshark-common package
-    require='__package_apt/wireshark' \
-        __debconf_set_selections wireshark \
-            --line 'wireshark-common wireshark-common/install-setuid boolean true' \
-            --reconfigure
+   # Reconfigure wireshark-common package
+   require=__package_apt/wireshark \
+   __debconf_set_selections wireshark \
+      --line 'wireshark-common wireshark-common/install-setuid boolean true' \
+      --reconfigure
 
 
 SEE ALSO
 --------
-- :strong:`cdist-type__update_alternatives`\ (7)
-- :strong:`debconf-set-selections`\ (1)
+* :strong:`cdist-type__update_alternatives`\ (7)
+* :strong:`debconf-set-selections`\ (1)
 
 
 AUTHORS
 -------
-| Nico Schottelius <nico-cdist--@--schottelius.org>
-| Dennis Camera <dennis.camera--@--ssrq-sds-fds.ch>
+* Nico Schottelius <nico-cdist--@--schottelius.org>
+* Dennis Camera <dennis.camera--@--ssrq-sds-fds.ch>
 
 
 COPYING

--- a/type/__directory/man.rst
+++ b/type/__directory/man.rst
@@ -11,13 +11,14 @@ DESCRIPTION
 This cdist type allows you to create or remove directories on the target.
 
 
-REQUIRED PARAMETERS
--------------------
-None.
-
-
 OPTIONAL PARAMETERS
 -------------------
+group
+   Group to chgrp to.
+mode
+   Unix permissions, suitable for chmod.
+owner
+   User to chown to.
 state
    'present', 'absent', 'exists' or 'pre-exists', defaults to 'present' where:
 
@@ -32,15 +33,6 @@ state
       check that the directory exists and is indeed a directory, but do not
       create or modify it.
 
-group
-   Group to chgrp to.
-
-mode
-   Unix permissions, suitable for chmod.
-
-owner
-   User to chown to.
-
 
 BOOLEAN PARAMETERS
 ------------------
@@ -50,25 +42,27 @@ parents
    to whatever mkdir -p does.
 
    Usually this means root:root, 0700.
-
 recursive
    If supplied the chgrp and chown call will run recursively.
    This does *not* influence the behaviour of chmod.
 
+
 MESSAGES
 --------
 chgrp <group>
-    Changed group membership
+   Changed group membership
 chown <owner>
-    Changed owner
+   Changed owner
 chmod <mode>
-    Changed mode
+   Changed mode
 create
-    Empty directory was created
+   Empty directory was created
 remove
-    Directory exists, but state is absent, directory will be removed by generated code.
+   Directory exists, but state is absent, directory will be removed by generated
+   code.
 remove non directory
-    Something other than a directory with the same name exists and was removed prior to create.
+   Something other than a directory with the same name exists and was removed
+   prior to create.
 
 
 EXAMPLES
@@ -76,37 +70,37 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # A silly example
-    __directory /tmp/foobar
+   # A silly example
+   __directory /tmp/foobar
 
-    # Remove a directory
-    __directory /tmp/foobar --state absent
+   # Remove a directory
+   __directory /tmp/foobar --state absent
 
-    # Ensure /etc exists correctly
-    __directory /etc --owner root --group root --mode 0755
+   # Ensure /etc exists correctly
+   __directory /etc --owner root --group root --mode 0755
 
-    # Create nfs service directory, including parents
-    __directory /home/services/nfs --parents
+   # Create nfs service directory, including parents
+   __directory /home/services/nfs --parents
 
-    # Change permissions recursively
-    __directory /home/services --recursive --owner root --group root
+   # Change permissions recursively
+   __directory /home/services --recursive --owner root --group root
 
-    # Setup a temp directory
-    __directory /local --mode 1777
+   # Setup a temp directory
+   __directory /local --mode 1777
 
-    # Take it all
-    __directory /home/services/kvm --recursive --parents \
-        --owner root --group root --mode 0755 --state present
+   # Take it all
+   __directory /home/services/kvm --recursive --parents \
+      --owner root --group root --mode 0755 --state present
 
 
 AUTHORS
 -------
-Nico Schottelius <nico-cdist--@--schottelius.org>
+* Nico Schottelius <nico-cdist--@--schottelius.org>
 
 
 COPYING
 -------
-Copyright \(C) 2011 Nico Schottelius. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2011 Nico Schottelius.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__download/man.rst
+++ b/type/__download/man.rst
@@ -16,7 +16,8 @@ If download happens in local machine, then environment variables like
 ``{http,https,ftp}_proxy`` etc can be used on cdist execution
 (``http_proxy=foo cdist config ...``).
 
-To change downloaded file's owner, group or permissions, use ``require='__download/path/to/file' __file ...``.
+To change downloaded file's owner, group or permissions, use
+``require='__download/path/to/file' __file ...``.
 
 
 REQUIRED PARAMETERS
@@ -27,9 +28,28 @@ url
 
 OPTIONAL PARAMETERS
 -------------------
+cmd-get
+   Command used for downloading.
+   Command must output to ``stdout``.
+   Parameter will be used for ``printf`` and must include only one
+   format specification ``%s`` which will become URL.
+   For example: ``wget -O - '%s'``.
+cmd-sum
+   Command used for checksum calculation.
+   Command output and ``--sum`` parameter must match.
+   Parameter will be used for ``printf`` and must include only one
+   format specification ``%s`` which will become destination.
+   For example: ``md5sum '%s' | awk '{print $1}'``.
 destination
    Downloaded file's destination in target. If unset, ``$__object_id`` is used.
+download
+   If ``local`` (default), then file is downloaded to local storage and copied
+   to target host. If ``remote``, then download happens in target.
 
+   For local downloads it is expected that usable utilities for downloading
+   exist in the system. Type will try to use ``curl``, ``fetch`` or ``wget``.
+onchange
+   Execute this command after download.
 sum
    Supported formats: ``cksum`` output without file name, MD5, SHA1 and SHA256.
 
@@ -44,58 +64,34 @@ sum
    For local downloads it is expected that usable utilities for checksum
    calculation exist in the system.
 
-download
-   If ``local`` (default), then file is downloaded to local storage and copied
-   to target host. If ``remote``, then download happens in target.
-
-   For local downloads it is expected that usable utilities for downloading
-   exist in the system. Type will try to use ``curl``, ``fetch`` or ``wget``.
-
-cmd-get
-   Command used for downloading.
-   Command must output to ``stdout``.
-   Parameter will be used for ``printf`` and must include only one
-   format specification ``%s`` which will become URL.
-   For example: ``wget -O - '%s'``.
-
-cmd-sum
-   Command used for checksum calculation.
-   Command output and ``--sum`` parameter must match.
-   Parameter will be used for ``printf`` and must include only one
-   format specification ``%s`` which will become destination.
-   For example: ``md5sum '%s' | awk '{print $1}'``.
-
-onchange
-   Execute this command after download.
-
 
 EXAMPLES
 --------
 
 .. code-block:: sh
 
-    __directory /opt/cpma
+   __directory /opt/cpma
 
-    require='__directory/opt/cpma' \
-        __download /opt/cpma/cnq3.zip \
-            --url https://cdn.playmorepromode.com/files/cnq3/cnq3-1.51.zip \
-            --sum 46da3021ca9eace277115ec9106c5b46
+   require='__directory/opt/cpma' \
+       __download /opt/cpma/cnq3.zip \
+           --url https://cdn.playmorepromode.com/files/cnq3/cnq3-1.51.zip \
+           --sum 46da3021ca9eace277115ec9106c5b46
 
-    require='__download/opt/cpma/cnq3.zip' \
-        __unpack /opt/cpma/cnq3.zip \
-            --backup-destination \
-            --preserve-archive \
-            --destination /opt/cpma/server
+   require='__download/opt/cpma/cnq3.zip' \
+       __unpack /opt/cpma/cnq3.zip \
+           --backup-destination \
+           --preserve-archive \
+           --destination /opt/cpma/server
 
 
 AUTHORS
 -------
-Ander Punnar <ander-at-kvlt-dot-ee>
+* Ander Punnar <ander-at-kvlt-dot-ee>
 
 
 COPYING
 -------
-Copyright \(C) 2021 Ander Punnar. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2021 Ander Punnar.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__dpkg_architecture/man.rst
+++ b/type/__dpkg_architecture/man.rst
@@ -3,44 +3,52 @@ cdist-type__dpkg_architecture(7)
 
 NAME
 ----
-cdist-type__dpkg_architecture - Handles foreign architectures on debian-like
-systems managed by `dpkg`
+cdist-type__dpkg_architecture - Handles foreign architectures on Debian-like
+systems managed by :strong:`dpkg`\ (1).
 
 
 DESCRIPTION
 -----------
 This type handles foreign architectures on systems managed by
 :strong:`dpkg`\ (1). The object id is the name of the architecture accepted by
-`dpkg`, which should be added or removed.
+:strong:`dpkg`\ (1), which should be added or removed.
 
 If the architecture is not setup on the system, it adds a new architecture as a
-new foreign architecture in `dpkg`. Then, it updates the apt package index to
-make packages from the new architecture available.
+new foreign architecture in :strong:`dpkg`\ (1). Then, it updates the apt
+package index to make packages from the new architecture available.
 
 If the architecture should be removed, it will remove it if it is not the base
 architecture on where the system was installed on. Before it, it will purge
-every package based on the "to be removed" architecture via `apt` to be able to
-remove the selected architecture.
-
-
-REQUIRED PARAMETERS
--------------------
-None.
+every package based on the "to be removed" architecture via :strong:`apt`\ (1)
+to be able to remove the selected architecture.
 
 
 OPTIONAL PARAMETERS
 -------------------
 state
-    ``present`` or ``absent``. Defaults to ``present``.
+   ``present`` or ``absent``.
+
+   Defaults to: ``present``.
 
 
 MESSAGES
 --------
 added
    Added the specified architecture
-
 removed
    Removed the specified architecture
+
+
+EXAMPLES
+--------
+
+.. code-block:: sh
+
+   # add i386 (32 bit) architecture
+   __dpkg_architecture i386
+
+   # remove it again :)
+   __dpkg_architecture i386 --state absent
 
 
 ABORTS
@@ -57,27 +65,13 @@ It will fail if it can not execute :strong:`apt`\ (8). It is assumed that it is
 already installed.
 
 
-EXAMPLES
---------
-
-.. code-block:: sh
-
-  # add i386 (32 bit) architecture
-  __dpkg_architecture i386
-
-  # remove it again :)
-  __dpkg_architecture i386 --state absent
-
-
 SEE ALSO
 --------
-`Multiarch on Debian systems <https://wiki.debian.org/Multiarch>`_
-
-`How to setup multiarch on Debian <https://wiki.debian.org/Multiarch/HOWTO>`_
-
-:strong:`dpkg`\ (1)
-:strong:`cdist-type__package_dpkg`\ (7)
-:strong:`cdist-type__package_apt`\ (7)
+* `Multiarch on Debian systems <https://wiki.debian.org/Multiarch>`_
+* `How to setup multiarch on Debian <https://wiki.debian.org/Multiarch/HOWTO>`_
+* :strong:`dpkg`\ (1)
+* :strong:`cdist-type__package_dpkg`\ (7)
+* :strong:`cdist-type__package_apt`\ (7)
 
 Useful commands:
 
@@ -92,12 +86,12 @@ Useful commands:
 
 AUTHORS
 -------
-Matthias Stecher <matthiasstecher at gmx.de>
+* Matthias Stecher <matthiasstecher at gmx.de>
 
 
 COPYING
 -------
-Copyright \(C) 2020 Matthias Stecher. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-ublished by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2020 Matthias Stecher.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__file/man.rst
+++ b/type/__file/man.rst
@@ -30,14 +30,28 @@ not a regular file).
 In any case, make sure that the file attributes are as specified.
 
 
-REQUIRED PARAMETERS
--------------------
-None.
-
 OPTIONAL PARAMETERS
 -------------------
+group
+   Group to :strong:`chgrp`\ (1) to.
+
+   Defaults to: ``root``
+mode
+   Unix permissions, suitable for chmod.
+
+   Defaults to a very secure ``0600``.
+onchange
+   The code to run if file is modified.
+owner
+   User to :strong:`chown`\ (1) to.
+
+   Defaults to: ``root``
+source
+   If supplied, copy this file from the host running cdist to the target.
+   If not supplied, an empty file or directory will be created.
+   If source is '-' (dash), take what was written to stdin as the file content.
 state
-   'present', 'absent', 'exists' or 'pre-exists', defaults to 'present' where:
+   One of:
 
    present
       the file is exactly the one from source
@@ -49,22 +63,8 @@ state
       check that the file exists and is a regular file, but do not
       create or modify it
 
-group
-   Group to chgrp to. Defaults to ``root``.
+   Defaults to: ``present``
 
-mode
-   Unix permissions, suitable for chmod. Defaults to a very secure ``0600``.
-
-owner
-   User to chown to. Defaults to ``root``.
-
-source
-   If supplied, copy this file from the host running cdist to the target.
-   If not supplied, an empty file or directory will be created.
-   If source is '-' (dash), take what was written to stdin as the file content.
-
-onchange
-   The code to run if file is modified.
 
 MESSAGES
 --------
@@ -75,7 +75,7 @@ chown <owner>
 chmod <mode>
    Changed mode
 create
-   Empty file was created (no --source specified)
+   Empty file was created (no ``--source`` specified)
 remove
    File exists, but state is absent, file will be removed by generated code.
 upload
@@ -87,38 +87,51 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Create  /etc/cdist-configured as an empty file
-    __file /etc/cdist-configured
-    # The same thing
-    __file /etc/cdist-configured --state present
-    # Use __file from another type
-    __file /etc/issue --source "$__type/files/archlinux" --state present
-    # Delete existing file
-    __file /etc/cdist-configured --state absent
-    # Supply some more settings
-    __file /etc/shadow --source "$__type/files/shadow" \
-       --owner root --group shadow --mode 0640 \
-       --state present
-    # Provide a default file, but let the user change it
-    __file /home/frodo/.bashrc --source "/etc/skel/.bashrc" \
-       --state exists \
-       --owner frodo --mode 0600
-    # Check that the file is present, show an error when it is not
-    __file /etc/somefile --state pre-exists
-    # Take file content from stdin
-    __file /tmp/whatever --owner root --group root --mode 644 --source - << DONE
-        Here goes the content for /tmp/whatever
-    DONE
+   # Create  /etc/cdist-configured as an empty file
+   __file /etc/cdist-configured
+
+   # The same thing
+   __file /etc/cdist-configured --state present
+
+   # Use __file from another type
+   __file /etc/issue \
+      --source "${__type:?}/files/archlinux"
+      --state present
+
+   # Delete existing file
+   __file /etc/cdist-configured --state absent
+
+   # Supply some more settings
+   __file /etc/shadow \
+      --owner root --group shadow --mode 0640 \
+      --state present \
+      --source "${__type:?}/files/shadow"
+
+   # Provide a default file, but let the user change it
+   __file /home/frodo/.bashrc \
+      --state exists \
+      --owner frodo --mode 0600 \
+      --source /etc/skel/.bashrc
+
+   # Check that the file is present, show an error when it is not
+   __file /etc/somefile --state pre-exists
+
+   # Take file content from stdin
+   __file /tmp/whatever \
+      --owner root --group root --mode 644 \
+      --source - <<'EOF'
+   Here goes the content for /tmp/whatever
+   EOF
 
 
 AUTHORS
 -------
-Nico Schottelius <nico-cdist--@--schottelius.org>
+* Nico Schottelius <nico-cdist--@--schottelius.org>
 
 
 COPYING
 -------
-Copyright \(C) 2011-2013 Nico Schottelius. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2011-2013 Nico Schottelius.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__git/man.rst
+++ b/type/__git/man.rst
@@ -14,52 +14,51 @@ This cdist type allows you to clone git repositories
 REQUIRED PARAMETERS
 -------------------
 source
-    Specifies the git remote to clone from
+   Specifies the git remote to clone from
 
 
 OPTIONAL PARAMETERS
 -------------------
-state
-    Either "present" or "absent", defaults to "present"
-
 branch
-    Create this branch by checking out the remote branch of this name
-
+   Create this branch by checking out the remote branch of this name
 group
-   Group to chgrp to.
-
+   Group to :strong:`chgrp`\ (1) to.
 mode
    Unix permissions, suitable for chmod.
-
 owner
-   User to chown to.
-
+   User to :strong:`chown`\ (1) to.
 recursive
    Passes the --recurse-submodules flag to git when cloning the repository.
-
 shallow
-   Sets --depth=1 and --shallow-submodules for cloning repositories with big history.
+   Sets ``--depth=1`` and ``--shallow-submodules`` for cloning repositories with
+   a big history.
+state
+   Either ``present`` or ``absent``.
 
+   Defaults to: ``present``
 
 EXAMPLES
 --------
 
 .. code-block:: sh
 
-    __git /home/services/dokuwiki --source git://github.com/splitbrain/dokuwiki.git
+   __git /home/services/dokuwiki \
+       --source git://github.com/splitbrain/dokuwiki.git
 
-    # Checkout cdist, stay on branch 2.1
-    __git /home/nico/cdist --source git@code.ungleich.ch:ungleich-public/cdist.git --branch 2.1
+   # Checkout cdist, stay on branch 2.1
+   __git /home/nico/cdist \
+      --source git@code.ungleich.ch:ungleich-public/cdist.git \
+      --branch 2.1
 
 
 AUTHORS
 -------
-Nico Schottelius <nico-cdist--@--schottelius.org>
+* Nico Schottelius <nico-cdist--@--schottelius.org>
 
 
 COPYING
 -------
-Copyright \(C) 2012 Nico Schottelius. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2012 Nico Schottelius.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__group/man.rst
+++ b/type/__group/man.rst
@@ -11,39 +11,34 @@ DESCRIPTION
 This cdist type allows you to create or modify groups on the target.
 
 
-REQUIRED PARAMETERS
--------------------
-None.
-
-
 OPTIONAL PARAMETERS
 -------------------
-state
-    absent or present, defaults to present
 gid
    see groupmod(8)
 password
    see above
+state
+   absent or present, defaults to present
 
 
 BOOLEAN PARAMETERS
 ------------------
 system
-    see groupadd(8), apply only on group creation
+   see groupadd(8), apply only on group creation
 
 
 MESSAGES
 --------
 mod
-    group is modified
+   group is modified
 add
-    New group added
+   New group added
 remove
-    group is removed
+   group is removed
 change <property> <new_value> <current_value>
-    Changed group property from current_value to new_value
+   Changed group property from current_value to new_value
 set <property> <new_value>
-    set property to new value, property was not set before
+   set property to new value, property was not set before
 
 
 EXAMPLES
@@ -51,30 +46,30 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Create a group 'foobar' with operating system default settings
-    __group foobar
+   # Create a group 'foobar' with operating system default settings
+   __group foobar
 
-    # Remove the 'foobar' group
-    __group foobar --state absent
+   # Remove the 'foobar' group
+   __group foobar --state absent
 
-    # Create a system group 'myservice' with operating system default settings
-    __group myservice --system
+   # Create a system group 'myservice' with operating system default settings
+   __group myservice --system
 
-    # Same but with a specific gid
-    __group foobar --gid 1234
+   # Same but with a specific gid
+   __group foobar --gid 1234
 
-    # Same but with a gid and password
-    __group foobar --gid 1234 --password 'crypted-password-string'
+   # Same but with a gid and password
+   __group foobar --gid 1234 --password 'crypted-password-string'
 
 
 AUTHORS
 -------
-Steven Armstrong <steven-cdist--@--armstrong.cc>
+* Steven Armstrong <steven-cdist--@--armstrong.cc>
 
 
 COPYING
 -------
-Copyright \(C) 2011-2015 Steven Armstrong. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2011-2015 Steven Armstrong.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__hostname/man.rst
+++ b/type/__hostname/man.rst
@@ -14,10 +14,6 @@ Sets the hostname on various operating systems.
 `RFC 1178 <https://tools.ietf.org/html/rfc1178>`_.
 
 
-REQUIRED PARAMETERS
--------------------
-None.
-
 OPTIONAL PARAMETERS
 -------------------
 name
@@ -28,28 +24,30 @@ name
 MESSAGES
 --------
 changed
-    Changed the hostname
+   Changed the hostname
+
 
 EXAMPLES
 --------
 
 .. code-block:: sh
 
-    # take hostname from __target_host
-    __hostname
+   # take hostname from __target_host
+   __hostname
 
-    # set hostname explicitly
-    __hostname --name some-static-hostname
+   # set hostname explicitly
+   __hostname --name some-static-hostname
 
 
 AUTHORS
 -------
-Steven Armstrong <steven-cdist--@--armstrong.cc>
+* Steven Armstrong <steven-cdist--@--armstrong.cc>
+* Dennis Camera <dennis.camera--@--ssrq-sds-fds.ch>
 
 
 COPYING
 -------
-Copyright \(C) 2012 Steven Armstrong. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2012 Steven Armstrong, 2019 Dennis Camera.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__hosts/man.rst
+++ b/type/__hosts/man.rst
@@ -3,59 +3,60 @@ cdist-type__hosts(7)
 
 NAME
 ----
-
 cdist-type__hosts - manage entries in /etc/hosts
+
 
 DESCRIPTION
 -----------
+Manage entries in the ``/etc/hosts`` file.
 
-Add or remove entries from */etc/hosts* file.
 
 OPTIONAL PARAMETERS
 -------------------
-
-state
-    If state is ``present``, make *object_id* resolve to *ip*. If
-    state is ``absent``, *object_id* will no longer resolve via
-    */etc/hosts*, if it was previously configured with this type.
-    Manually inserted entries are unaffected.
-
-ip
-    IP address, to which hostname (=\ *object_id*) must resolve. If
-    state is ``present``, this parameter is mandatory, if state is
-    ``absent``, this parameter is silently ignored.
-
 alias
-    An alias for the hostname.
-    This parameter can be specified multiple times (once per alias).
+   An alias for the hostname.
+
+This parameter can be specified multiple times (once per alias).
+ip
+   IP address, to which hostname (``__object_id``) should resolve.
+   If ``--state present``, this parameter is mandatory.
+   If ``--state absent``, this parameter is silently ignored.
+state
+   If ``--state present``, make ``__object_id`` resolve to ``--ip``.
+   If ``--state absent``, ``__object_id`` will no longer resolve via
+   ``/etc/hosts``, if it was previously configured with this type.
+
+   Manually inserted entries are unaffected.
+
 
 EXAMPLES
 --------
 
 .. code-block:: sh
 
-    # Now `funny' resolves to 192.168.1.76,
-    __hosts funny --ip 192.168.1.76
-    # and `happy' no longer resolve via /etc/hosts if it was
-    # previously configured via __hosts.
-    __hosts happy --state absent
+   # Now `funny' resolves to 192.168.1.76,
+   __hosts funny --ip 192.168.1.76
 
-    __hosts srv1.example.com --ip 192.168.0.42 --alias srv1
+   # and `happy' no longer resolve via /etc/hosts if it was
+   # previously configured via __hosts.
+   __hosts happy --state absent
+
+   __hosts srv1.example.com --ip 192.168.0.42 --alias srv1
+
 
 SEE ALSO
 --------
+* :strong:`hosts`\ (5)
 
-:strong:`hosts`\ (5)
 
 AUTHORS
 -------
-| Dmitry Bogatov <KAction@gnu.org>
-| Dennis Camera <dennis.camera--@--ssrq-sds-fds.ch>
+* Dmitry Bogatov <KAction@gnu.org>
+* Dennis Camera <dennis.camera--@--ssrq-sds-fds.ch>
 
 
 COPYING
 -------
-
 Copyright \(C) 2015-2016 Dmitry Bogatov, 2019 Dennis Camera.
 You can redistribute it and/or modify it under the terms of the GNU General
 Public License as published by the Free Software Foundation, either version 3 of

--- a/type/__hwclock/man.rst
+++ b/type/__hwclock/man.rst
@@ -15,25 +15,15 @@ system.
 REQUIRED PARAMETERS
 -------------------
 mode
-    What mode the hardware clock is in.
+   What mode the hardware clock is in.
 
-    Acceptable values:
+   Acceptable values:
 
-    localtime
-        The hardware clock is set to local time (common for systems also running
-        Windows.)
-    UTC
-        The hardware clock is set to UTC (common on UNIX systems.)
-
-
-OPTIONAL PARAMETERS
--------------------
-None.
-
-
-BOOLEAN PARAMETERS
-------------------
-None.
+   localtime
+      The hardware clock is set to local time (common for systems also running
+      Windows.)
+   UTC
+      The hardware clock is set to UTC (common on UNIX systems.)
 
 
 EXAMPLES
@@ -41,23 +31,23 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Make the operating system treat the time read from the hwclock as UTC.
-    __hwclock --mode UTC
+   # Make the operating system treat the time read from the hwclock as UTC.
+   __hwclock --mode UTC
 
 
 SEE ALSO
 --------
-:strong:`hwclock`\ (8)
+* :strong:`hwclock`\ (8)
 
 
 AUTHORS
 -------
-Dennis Camera <dennis.camera@ssrq-sds-fds.ch>
+* Dennis Camera <dennis.camera--@--ssrq-sds-fds.ch>
 
 
 COPYING
 -------
-Copyright \(C) 2020 Dennis Camera. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2020 Dennis Camera.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__key_value/man.rst
+++ b/type/__key_value/man.rst
@@ -14,47 +14,48 @@ file.
 
 REQUIRED PARAMETERS
 -------------------
-file
-   The file to operate on.
 delimiter
    The delimiter which separates the key from the value.
+file
+   The file to operate on.
 
 
 OPTIONAL PARAMETERS
 -------------------
-state
-    present or absent, defaults to present. If present, sets the key to value,
-    if absent, removes the key from the file.
-key
-    The key to change. Defaults to object_id.
-value
-    The value for the key. Optional if state=absent, required otherwise.
 comment
-    If supplied, the value will be inserted before the line with the key,
-    but only if the key or value must be changed.
-    You need to ensure yourself that the line is prefixed with the correct
-    comment sign. (for example # or ; or wathever ..)
+   If supplied, the value will be inserted before the line with the key,
+   but only if the key or value must be changed.
+   You need to ensure yourself that the line is prefixed with the correct
+   comment sign. (for example # or ; or wathever ..)
+key
+   The key to change. Defaults to object_id.
 onchange
-   The code to run if the key or value changes (i.e. is inserted, removed or replaced).
+   The code to run if the key or value changes (i.e. is inserted, removed or
+   replaced).
+state
+   present or absent, defaults to present. If present, sets the key to value,
+   if absent, removes the key from the file.
+value
+   The value for the key. Optional if state=absent, required otherwise.
 
 
 BOOLEAN PARAMETERS
 ------------------
 exact_delimiter
-    If supplied, treat additional whitespaces between key, delimiter and value
-    as wrong value.
+   If supplied, treat additional whitespaces between key, delimiter and value
+   as wrong value.
 
 
 MESSAGES
 --------
 remove
-    Removed existing key and value
+   Removed existing key and value
 insert
-    Added key and value
+   Added key and value
 change
-    Changed value of existing key
+   Changed value of existing key
 create
-    A new line was inserted in a new file
+   A new line was inserted in a new file
 
 
 EXAMPLES
@@ -62,35 +63,47 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Set the maximum system user id
-    __key_value SYS_UID_MAX --file /etc/login.defs --value 666 --delimiter ' '
+   # Set the maximum system user id
+   __key_value SYS_UID_MAX \
+      --file /etc/login.defs \
+      --value 666 \
+      --delimiter ' '
 
-    # Same with fancy id
-    __key_value my-fancy-id --file /etc/login.defs --key SYS_UID_MAX --value 666 \
-       --delimiter ' '
+   # Same with fancy id
+   __key_value my-fancy-id \
+      --file /etc/login.defs \
+      --key SYS_UID_MAX --value 666 \
+      --delimiter ' '
 
-    # Enable packet forwarding
-    __key_value net.ipv4.ip_forward --file /etc/sysctl.conf --value 1 \
-       --delimiter ' = ' --comment '# my linux kernel should act as a router'
+   # Enable packet forwarding
+   __key_value net.ipv4.ip_forward \
+      --file /etc/sysctl.conf \
+      --value 1 \
+      --delimiter ' = ' \
+      --comment '# my linux kernel should act as a router'
 
-    # Remove existing key/value
-    __key_value LEGACY_KEY --file /etc/somefile --state absent --delimiter '='
+   # Remove existing key/value
+   __key_value LEGACY_KEY \
+      --file /etc/somefile \
+      --state absent \
+      --delimiter '='
 
 
 MORE INFORMATION
 ----------------
 This type try to handle as many values as possible, so it doesn't use regexes.
-So you need to exactly specify the key and delimiter. Delimiter can be of any length.
+So you need to exactly specify the key and delimiter. Delimiter can be of any
+length.
 
 
 AUTHORS
 -------
-Steven Armstrong <steven-cdist--@--armstrong.cc>
+* Steven Armstrong <steven-cdist--@--armstrong.cc>
 
 
 COPYING
 -------
-Copyright \(C) 2011 Steven Armstrong. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2011 Steven Armstrong.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__line/man.rst
+++ b/type/__line/man.rst
@@ -11,63 +11,47 @@ DESCRIPTION
 This cdist type allows you to add lines and remove lines from files.
 
 
-REQUIRED PARAMETERS
--------------------
-None.
-
-
 OPTIONAL PARAMETERS
 -------------------
 after
-    Insert the given line after this pattern.
-
+   Insert the given line after this pattern.
 before
-    Insert the given line before this pattern.
-
+   Insert the given line before this pattern.
 file
-    If supplied, use this as the destination file.
-    Otherwise the object_id is used.
-
+   If supplied, use this as the destination file.
+   Otherwise the ``__object_id`` is used.
 line
-    Specifies the line which should be absent or present.
+   Specifies the line which should be absent or present.
 
-    Must be present, if state is 'present' or 'replace'.
-    Ignored if regex is given and state is 'absent'.
-
-regex
-    If state is 'present', search for this pattern and if it matches add
-    the given line.
-
-    If state is 'absent', ensure all lines matching the regular expression
-    are absent.
-
-    If state is 'replace', ensure all lines matching the regular expression
-    are exactly 'line'.
-
-    The regular expression is interpreted by awk's match function.
-
-state
-    'present', 'absent' or 'replace', defaults to 'present'.
-
+   Must be set, if ``--state present`` or ``--state replace``.
+   Ignored if ``--regex`` is used and ``--state absent``.
 onchange
-    The code to run if line is added, removed or updated.
+   The code to run if line is added, removed or updated.
+regex
+   If ``--state present``, search for this pattern and if it matches add
+   the given line.
 
+   If ``--state absent``, ensure all lines matching the regular expression
+   are absent.
 
-BOOLEAN PARAMETERS
-------------------
-None.
+   If ``--state replace``, ensure all lines matching the regular expression
+   are exactly ``--line``.
+
+   The regular expression is interpreted by awk's match function.
+state
+   ``present``, ``absent``, or ``replace``
+
+   Defaults to: ``present``
 
 
 MESSAGES
 --------
 added
-    The line was added.
-
+   The line was added.
 updated
-    The line or its position was changed.
-
+   The line or its position was changed.
 removed
-    The line was removed.
+   The line was removed.
 
 
 EXAMPLES
@@ -75,51 +59,53 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Manage a hosts entry for www.example.com.
-    __line /etc/hosts \
-        --line '127.0.0.2 www.example.com'
+   # Manage a hosts entry for www.example.com.
+   __line /etc/hosts \
+       --line '127.0.0.2 www.example.com'
 
-    # Manage another hosts entry for test.example.com.
-    __line hosts:test.example.com \
-        --file /etc/hosts \
-        --line '127.0.0.3 test.example.com'
+   # Manage another hosts entry for test.example.com.
+   __line hosts:test.example.com \
+       --file /etc/hosts \
+       --line '127.0.0.3 test.example.com'
 
-    # Remove the line starting with TIMEZONE from the /etc/rc.conf file.
-    __line legacy_timezone \
-       --file /etc/rc.conf \
-       --regex 'TIMEZONE=.*' \
-       --state absent
+   # Remove the line starting with TIMEZONE from the /etc/rc.conf file.
+   __line legacy_timezone \
+      --file /etc/rc.conf \
+      --regex 'TIMEZONE=.*' \
+      --state absent
 
-    # Insert a line before another one.
-    __line password-auth-local:classify \
-        --file /etc/pam.d/password-auth-local \
-        --line '-session required pam_exec.so debug log=/tmp/classify.log /usr/local/libexec/classify' \
-        --before '^session[[:space:]]+include[[:space:]]+password-auth-ac$'
+   # Insert a line before another one.
+   __line password-auth-local:classify \
+       --file /etc/pam.d/password-auth-local \
+       --line '-session required pam_exec.so debug log=/tmp/classify.log /usr/local/libexec/classify' \
+       --before '^session[[:space:]]+include[[:space:]]+password-auth-ac$'
 
-    # Insert a line after another one.
-    __line password-auth-local:classify \
-        --file /etc/pam.d/password-auth-local \
-        --line '-session required pam_exec.so debug log=/tmp/classify.log /usr/local/libexec/classify' \
-        --after '^session[[:space:]]+include[[:space:]]+password-auth-ac$'
+   # Insert a line after another one.
+   __line password-auth-local:classify \
+       --file /etc/pam.d/password-auth-local \
+       --line '-session required pam_exec.so debug log=/tmp/classify.log /usr/local/libexec/classify' \
+       --after '^session[[:space:]]+include[[:space:]]+password-auth-ac$'
 
-    # Uncomment as needed and set a value in a configuration file.
-    __line /etc/example.conf \
-        --line 'SomeSetting SomeValue' \
-        --regex '^(#[[:space:]]*)?SomeSetting[[:space:]]' \
-        --state replace
+   # Uncomment as needed and set a value in a configuration file.
+   __line /etc/example.conf \
+       --line 'SomeSetting SomeValue' \
+       --regex '^(#[[:space:]]*)?SomeSetting[[:space:]]' \
+       --state replace
 
 
 SEE ALSO
 --------
-:strong:`cdist-type`\ (7)
+* :strong:`cdist-type`\ (7)
 
 
 AUTHORS
 -------
-Steven Armstrong <steven-cdist--@--armstrong.cc>
+* Steven Armstrong <steven-cdist--@--armstrong.cc>
 
 
 COPYING
 -------
-Copyright \(C) 2018 Steven Armstrong. Free use of this software is
-granted under the terms of the GNU General Public License version 3 (GPLv3).
+Copyright \(C) 2018 Steven Armstrong.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__link/man.rst
+++ b/type/__link/man.rst
@@ -9,38 +9,47 @@ cdist-type__link - Manage links (hard and symbolic)
 DESCRIPTION
 -----------
 This cdist type allows you to manage hard and symbolic links.
-The given object id is the destination for the link.
+The ``__object_id`` is the destination for the link.
 
 
 REQUIRED PARAMETERS
 -------------------
 source
    Specifies the link source.
-
 type
-   Specifies the link type: Either hard or symbolic.
+   One of:
+
+   hard
+      create a hard link
+   symbolic
+      create a symbolic link
 
 
 OPTIONAL PARAMETERS
 -------------------
 state
-   'present' or 'absent', defaults to 'present'
+   One of:
+
+   present
+      the link exists
+   absent
+      the link does not exist
+
+   Defaults to: ``present``
 
 
 MESSAGES
 --------
-
 created <destination>
    Link to destination was created.
-
 removed <destination>
    Link to destination was removed.
-
 removed <destination> (directory)
-   Destination was removed because state is ``present`` and destination was directory.
-
+   Destination was removed because ``--state present`` and destination was a
+   directory.
 removed <destination> (wrongsource)
-   Destination was removed because state is ``present`` and destination link source was wrong.
+   Destination was removed because ``--state present`` and destination link
+   source was wrong.
 
 
 EXAMPLES
@@ -48,29 +57,31 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Create hard link of /etc/shadow
-    __link /root/shadow --source /etc/shadow --type hard
+   # Create hard link of /etc/shadow
+   __link /root/shadow --source /etc/shadow --type hard
 
-    # Relative symbolic link
-    __link /etc/apache2/sites-enabled/www.test.ch   \
-       --source ../sites-available/www.test.ch      \
-       --type symbolic
+   # Relative symbolic link
+   __link /etc/apache2/sites-enabled/www.test.ch \
+      --source ../sites-available/www.test.ch \
+      --type symbolic
 
-    # Absolute symbolic link
-    __link /opt/plone --source /home/services/plone --type symbolic
+   # Absolute symbolic link
+   __link /opt/plone \
+      --source /home/services/plone \
+      --type symbolic
 
-    # Remove link
-    __link /opt/plone --state absent
+   # Remove link
+   __link /opt/plone --state absent
 
 
 AUTHORS
 -------
-Nico Schottelius <nico-cdist--@--schottelius.org>
+* Nico Schottelius <nico-cdist--@--schottelius.org>
 
 
 COPYING
 -------
-Copyright \(C) 2011-2012 Nico Schottelius. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2011-2012 Nico Schottelius.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__locale/man.rst
+++ b/type/__locale/man.rst
@@ -23,28 +23,31 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Add locale de_CH.UTF-8
-    __locale de_CH.UTF-8
+   # Add locale de_CH.UTF-8
+   __locale de_CH.UTF-8
 
-    # Same as above, but more explicit
-    __locale de_CH.UTF-8 --state present
+   # Same as above, but more explicit
+   __locale de_CH.UTF-8 --state present
 
-    # Remove colourful British English
-    __locale en_GB.UTF-8 --state absent
+   # Remove colourful British English
+   __locale en_GB.UTF-8 --state absent
 
 
 SEE ALSO
 --------
-:strong:`locale`\ (1), :strong:`localedef`\ (1), :strong:`cdist-type__locale_system`\ (7)
+* :strong:`locale`\ (1)
+* :strong:`localedef`\ (1)
+* :strong:`cdist-type__locale_system`\ (7)
 
 
 AUTHORS
 -------
-Nico Schottelius <nico-cdist--@--schottelius.org>
+* Nico Schottelius <nico-cdist--@--schottelius.org>
 
 
 COPYING
 -------
-Copyright \(C) 2013-2019 Nico Schottelius. Free use of this software is
-granted under the terms of the GNU General Public License version 3 or
-later (GPLv3+).
+Copyright \(C) 2013-2019 Nico Schottelius.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__locale_system/man.rst
+++ b/type/__locale_system/man.rst
@@ -15,15 +15,19 @@ The name of the locale category is given as the object id
 
 OPTIONAL PARAMETERS
 -------------------
-
 state
-    present or absent, defaults to present.
-    If present, sets the locale category to the given value.
-    If absent, removes the locale category from the system file.
+   One of:
 
+   ``present``
+      set the locale category to the given value
+   ``absent``
+      remove the locale category from the system file
+
+   Defaults to: ``present``
 value
-    The value for the locale category.
-    Defaults to en_US.UTF-8.
+   The value for the locale category.
+
+   Defaults to: ``en_US.UTF-8``
 
 
 EXAMPLES
@@ -31,34 +35,36 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Set LANG to en_US.UTF-8
-    __locale_system LANG
+   # Set LANG to en_US.UTF-8
+   __locale_system LANG
 
-    # Same as above, but more explicit
-    __locale_system LANG --value en_US.UTF-8
+   # Same as above, but more explicit
+   __locale_system LANG --value en_US.UTF-8
 
-    # Set category LC_MESSAGES to de_CH.UTF-8
-    __locale_system LC_MESSAGES --value de_CH.UTF-8
+   # Set category LC_MESSAGES to de_CH.UTF-8
+   __locale_system LC_MESSAGES --value de_CH.UTF-8
 
-    # Remove setting for LC_ALL
-    __locale_system LC_ALL --state absent
-
+   # Remove setting for LC_ALL
+   __locale_system LC_ALL --state absent
 
 
 SEE ALSO
 --------
-:strong:`locale`\ (1), :strong:`localedef`\ (1), :strong:`cdist-type__locale`\ (7)
+* :strong:`locale`\ (1)
+* :strong:`localedef`\ (1)
+* :strong:`cdist-type__locale`\ (7)
 
 
 AUTHORS
 -------
-| Steven Armstrong <steven-cdist--@--armstrong.cc>
-| Carlos Ortigoza <carlos.ortigoza--@--ungleich.ch>
-| Nico Schottelius <nico.schottelius--@--ungleich.ch>
+* Steven Armstrong <steven-cdist--@--armstrong.cc>
+* Carlos Ortigoza <carlos.ortigoza--@--ungleich.ch>
+* Nico Schottelius <nico.schottelius--@--ungleich.ch>
 
 
 COPYING
 -------
-Copyright \(C) 2016 Nico Schottelius. Free use of this software is
-granted under the terms of the GNU General Public License version 3 or
-later (GPLv3+).
+Copyright \(C) 2016 Nico Schottelius.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__localedef/man.rst
+++ b/type/__localedef/man.rst
@@ -30,31 +30,32 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Add locale de_CH.UTF-8
-    __localedef de_CH.UTF-8
+   # Add locale de_CH.UTF-8
+   __localedef de_CH.UTF-8
 
-    # Same as above, but more explicit
-    __localedef de_CH.UTF-8 --state present
+   # Same as above, but more explicit
+   __localedef de_CH.UTF-8 --state present
 
-    # Remove colourful British English
-    __localedef en_GB.UTF-8 --state absent
+   # Remove colourful British English
+   __localedef en_GB.UTF-8 --state absent
 
 
 SEE ALSO
 --------
-:strong:`locale`\ (1),
-:strong:`localedef`\ (1),
-:strong:`cdist-type__locale_system`\ (7)
+* :strong:`locale`\ (1)
+* :strong:`localedef`\ (1)
+* :strong:`cdist-type__locale_system`\ (7)
 
 
 AUTHORS
 -------
-| Dennis Camera <dennis.camera--@--ssrq-sds-fds.ch>
-| Nico Schottelius <nico-cdist--@--schottelius.org>
+* Dennis Camera <dennis.camera--@--ssrq-sds-fds.ch>
+* Nico Schottelius <nico-cdist--@--schottelius.org>
 
 
 COPYING
 -------
-Copyright \(C) 2013-2019 Nico Schottelius, 2020 Dennis Camera. Free use of this
-software is granted under the terms of the GNU General Public License version 3
-or later (GPLv3+).
+Copyright \(C) 2013-2019 Nico Schottelius, 2020 Dennis Camera.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__motd/man.rst
+++ b/type/__motd/man.rst
@@ -8,19 +8,15 @@ cdist-type__motd - Manage message of the day
 
 DESCRIPTION
 -----------
-This cdist type allows you to easily setup /etc/motd.
+This cdist type allows you to easily setup ``/etc/motd``.
 
 .. note::
-      In some OS, motd is a bit special, check `motd(5)`.
-      Currently Debian, Devuan, Ubuntu and FreeBSD are taken into account.
-      If your OS of choice does something besides /etc/motd, check the source
-      and contribute support for it.
-      Otherwise it will likely just work.
 
-
-REQUIRED PARAMETERS
--------------------
-None.
+   In some OS, motd is a bit special, check :strong:`motd`\ (5).
+   Currently Debian, Devuan, Ubuntu and FreeBSD are taken into account.
+   If your OS of choice does something besides /etc/motd, check the source
+   and contribute support for it.
+   Otherwise it will likely just work.
 
 
 OPTIONAL PARAMETERS
@@ -36,30 +32,30 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Use cdist defaults
-    __motd
+   # Use cdist defaults
+   __motd
 
-    # Supply source file from a different type
-    __motd --source "$__type/files/my-motd"
+   # Supply source file from a different type
+   __motd --source "$__type/files/my-motd"
 
-    # Supply source from stdin
-    __motd --source "-" <<EOF
-    Take this kiss upon the brow!
-    And, in parting from you now,
-    Thus much let me avow-
-    You are not wrong, who deem
-    That my days have been a dream
-    EOF
+   # Supply source from stdin
+   __motd --source "-" <<EOF
+   Take this kiss upon the brow!
+   And, in parting from you now,
+   Thus much let me avow-
+   You are not wrong, who deem
+   That my days have been a dream
+   EOF
 
 
 AUTHORS
 -------
-Nico Schottelius <nico-cdist--@--schottelius.org>
+* Nico Schottelius <nico-cdist--@--schottelius.org>
 
 
 COPYING
 -------
-Copyright \(C) 2020 Nico Schottelius. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2020 Nico Schottelius.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__mount/man.rst
+++ b/type/__mount/man.rst
@@ -8,49 +8,45 @@ cdist-type__mount - Manage filesystem mounts
 
 DESCRIPTION
 -----------
-Manage filesystem mounts either via /etc/fstab or manually.
-
-
-REQUIRED PARAMETERS
--------------------
-None.
+Manage filesystem mounts either via ``/etc/fstab`` or manually.
 
 
 OPTIONAL PARAMETERS
 -------------------
 device
-   device to mount at path, defaults to 'none'. see mount(8)
+   device to mount at path. see :strong:`mount`\ (8).
 
+   Defaults to: ``none``
 dump
-   value for the dump field in fstab. see fstab(5)
-   defaults to 0.
+   value for the dump field in fstab. see :strong:`fstab`\ (5)
 
-   This parameter is ignored, if the nofstab parameter is given.
+   Defaults to: 0
 
+   This parameter is ignored, if the ``--nofstab`` parameter is used.
 options
-   comma separated string of options, see mount(8)
-
+   comma separated string of options, see :strong:`mount`\ (8).
 pass
-   value for the pass field in fstab. see fstab(5)
-   defaults to 0.
+   value for the pass field in fstab. see :strong:`fstab`\ (5).
 
-   This parameter is ignored, if the nofstab parameter is given.
+   Defaults to: 0
 
+   This parameter is ignored, if the ``--nofstab`` parameter is used.
 path
-   mount point where to mount the device, see mount(8).
-   Defaults to __object_id
+   mount point where to mount the device, see :strong:`mount`\ (8).
 
+   Defaults to: ``__object_id``
 state
-   either present or absent. Defaults to present.
+   either ``present`` or ``absent``.
 
+   Defaults to: ``present``
 type
-   vfstype, see mount(8)
+   vfstype, see :strong:`mount`\ (8).
 
 
 BOOLEAN PARAMETERS
 ------------------
 nofstab
-   do not manage an entry in /etc/fstab
+   do not manage an entry in ``/etc/fstab``
 
 
 EXAMPLES
@@ -58,27 +54,27 @@ EXAMPLES
 
 .. code-block:: sh
 
-    __mount /some/dir \
-       --device /dev/sdc3 \
-       --type xfs \
-       --options "defaults,ro"
-       --dump 0 \
-       --pass 1
+   __mount /some/dir \
+      --device /dev/sdc3 \
+      --type xfs \
+      --options "defaults,ro"
+      --dump 0 \
+      --pass 1
 
-    __mount /var/lib/one \
-       --device mfsmount \
-       --type fuse \
-       --options "mfsmaster=mfsmaster.domain.tld,mfssubfolder=/one,nonempty,_netdev"
+   __mount /var/lib/one \
+      --device mfsmount \
+      --type fuse \
+      --options "mfsmaster=mfsmaster.domain.tld,mfssubfolder=/one,nonempty,_netdev"
 
 
 AUTHORS
 -------
-Steven Armstrong <steven-cdist--@--armstrong.cc>
+* Steven Armstrong <steven-cdist--@--armstrong.cc>
 
 
 COPYING
 -------
-Copyright \(C) 2014 Steven Armstrong. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2014 Steven Armstrong.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__package/man.rst
+++ b/type/__package/man.rst
@@ -12,28 +12,32 @@ This cdist type allows you to install or uninstall packages on the target.
 It dispatches the actual work to the package system dependent types.
 
 
-REQUIRED PARAMETERS
--------------------
-None
-
-
 OPTIONAL PARAMETERS
 -------------------
 name
-    The name of the package to install. Default is to use the object_id as the
-    package name.
-version
-    The version of the package to install. Default is to install the version
-    chosen by the local package manager.
-type
-    The package type to use. Default is determined based on the $os explorer
-    variable.
-    e.g.
-    * __package_apt for Debian
-    * __package_emerge for Gentoo
+   The name of the package to install.
 
+   Defaults to: ``__object_id``
 state
-    Either "present" or "absent", defaults to "present"
+   One of:
+
+   present
+      the package is installed
+   absent
+      the package is uninstalled
+
+   Defaults to: ``present``
+type
+   The package manager to use.
+
+   The default is determined based on the target operating system.
+   e.g.
+   * :strong:`cdist-type__package_apt`\ (7) for Debian,
+   * :strong:`cdist-type__package_emerge`\ (7) for Gentoo.
+version
+   The version of the package to install.
+
+   Default is to install the version chosen by the local package manager.
 
 
 EXAMPLES
@@ -41,24 +45,24 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Install the package vim on the target
-    __package vim --state present
+   # Install the package vim on the target
+   __package vim --state present
 
-    # Same but install specific version
-    __package vim --state present --version 7.3.50
+   # Same but install specific version
+   __package vim --state present --version 7.3.50
 
-    # Force use of a specific package type
-    __package vim --state present --type __package_apt
+   # Force use of a specific package type
+   __package vim --state present --type __package_apt
 
 
 AUTHORS
 -------
-Steven Armstrong <steven-cdist--@--armstrong.cc>
+* Steven Armstrong <steven-cdist--@--armstrong.cc>
 
 
 COPYING
 -------
-Copyright \(C) 2011 Steven Armstrong. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2011 Steven Armstrong.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__package_apk/man.rst
+++ b/type/__package_apk/man.rst
@@ -11,18 +11,19 @@ DESCRIPTION
 apk is usually used on Alpine to manage packages.
 
 
-REQUIRED PARAMETERS
--------------------
-None
-
-
 OPTIONAL PARAMETERS
 -------------------
 name
    If supplied, use the name and not the object id as the package name.
-
 state
-    Either "present" or "absent", defaults to "present"
+   One of:
+
+   present
+      the package is installed
+   absent
+      the package is uninstalled
+
+   Defaults to: ``present``
 
 
 EXAMPLES
@@ -30,26 +31,26 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Ensure zsh in installed
-    __package_apk zsh --state present
+   # Ensure zsh in installed
+   __package_apk zsh --state present
 
-    # Remove package
-    __package_apk apache2 --state absent
+   # Remove package
+   __package_apk apache2 --state absent
 
 
 SEE ALSO
 --------
-:strong:`cdist-type__package`\ (7)
+* :strong:`cdist-type__package`\ (7)
 
 
 AUTHORS
 -------
-Nico Schottelius <nico-cdist--@--schottelius.org>
+* Nico Schottelius <nico-cdist--@--schottelius.org>
 
 
 COPYING
 -------
-Copyright \(C) 2019 Nico Schottelius. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2019 Nico Schottelius.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__package_apt/man.rst
+++ b/type/__package_apt/man.rst
@@ -13,46 +13,54 @@ The package will be installed without recommended or suggested packages. If
 such packages are required, install them separatly or use the parameter
 ``--install-recommends``.
 
-This type will update package index (before package installation) if any of following is true:
+This type will update package index (before package installation) if any of
+following is true:
 
-- ``/var/lib/apt/lists`` is missing.
-- ``/etc/apt/`` content is newer than ``/var/lib/apt/lists/`` (type will ``touch`` it after every update).
-- Package index cache is missing or older than one day.
+* ``/var/lib/apt/lists`` is missing.
+* ``/etc/apt/`` content is newer than ``/var/lib/apt/lists/`` (type will
+  :strong:`touch`\ (1) it after every update).
+* Package index cache is missing or older than one day.
 
-This type is nonparallel and only first instance of this type will update package index.
+This type is nonparallel and only first instance of this type will update
+package index.
 
 
 OPTIONAL PARAMETERS
 -------------------
 name
-    If supplied, use the name and not the object id as the package name.
+   The name of the package to install.
 
+   Defaults to: ``__object_id``
 state
-    Either "present" or "absent", defaults to "present"
+   One of:
 
+   present
+      the package is installed
+   absent
+      the package is uninstalled
+
+   Defaults to: ``present``
 target-release
-    Passed on to apt-get install, see apt-get(8).
-    Essentially allows you to retrieve packages from a different release
-
+   Passed on to apt-get install, see :strong:`apt-get`\ (8).
+   Essentially allows you to retrieve packages from a different release
 version
-    The version of the package to install. Default is to install the version
-    chosen by the local package manager.
+   The version of the package to install. Default is to install the version
+   chosen by the local package manager.
 
 
 BOOLEAN PARAMETERS
 ------------------
 install-recommends
-    If the package will be installed, it also installs recommended packages
-    with it. It will not install recommended packages if the original package
-    is already installed.
+   If the package will be installed, it also installs recommended packages
+   with it. It will not install recommended packages if the original package
+   is already installed.
 
-    In most cases, it is recommended to install recommended packages separatly
-    to control which additional packages will be installed to avoid useless
-    installed packages.
-
+   In most cases, it is recommended to install recommended packages separately
+   to control which additional packages will be installed to avoid useless
+   installed packages.
 purge-if-absent
-    If this parameter is given and state is ``absent``, the package is
-    purged from the system (using ``--purge``).
+   If this parameter is given and ``--state absent``, the package is
+   purged from the system (using ``--purge``).
 
 
 EXAMPLES
@@ -60,30 +68,30 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Ensure zsh in installed
-    __package_apt zsh --state present
+   # Ensure zsh in installed
+   __package_apt zsh --state present
 
-    # In case you only want *a* webserver, but don't care which one
-    __package_apt webserver --state present --name nginx
+   # In case you only want *a* webserver, but don't care which one
+   __package_apt webserver --state present --name nginx
 
-    # Remove obsolete package
-    __package_apt puppet --state absent
+   # Remove obsolete package
+   __package_apt puppet --state absent
 
 
 SEE ALSO
 --------
-:strong:`cdist-type__apt_update_index`\ (7)
-:strong:`cdist-type__package`\ (7)
+* :strong:`cdist-type__apt_update_index`\ (7)
+* :strong:`cdist-type__package`\ (7)
 
 
 AUTHORS
 -------
-Nico Schottelius <nico-cdist--@--schottelius.org>
+* Nico Schottelius <nico-cdist--@--schottelius.org>
 
 
 COPYING
 -------
-Copyright \(C) 2011-2012 Nico Schottelius. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2011-2012 Nico Schottelius.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__package_dpkg/man.rst
+++ b/type/__package_dpkg/man.rst
@@ -13,38 +13,44 @@ install packages that are provided locally as \*.deb files.
 
 The object given to this type must be the name of the deb package.
 The filename of the deb package has to follow Debian naming conventions, i.e.
-`${binary:Package}_${Version}_${Architecture}.deb` (see `dpkg-query(1)` for
-details).
+``${binary:Package}_${Version}_${Architecture}.deb`` (see
+:strong:`dpkg-query`\ (1) for details).
+
+
+REQUIRED PARAMETERS
+-------------------
+source
+   path to the \*.deb package
 
 
 OPTIONAL PARAMETERS
 -------------------
 state
-    `present` or `absent`, defaults to `present`.
+   One of:
 
-REQUIRED PARAMETERS
--------------------
-source
-    path to the \*.deb package
+   present
+      the package is installed
+   absent
+      the package is uninstalled
+
+   Defaults to: ``present``
 
 
 BOOLEAN PARAMETERS
 ------------------
 purge-if-absent
-    If this parameter is given when state is `absent`, the package is
-    purged from the system (using `--purge`).
+   If this parameter is given and ``--state absent``, the package is
+   purged from the system (using ``dpkg --purge``).
 
 
 MESSAGES
 --------
 installed
-    The deb-file was installed.
-
+   The .deb file was installed.
 removed (--remove)
-    The package was removed, keeping config.
-
+   The package was removed, keeping config.
 removed (--purge)
-    The package was removed including config (purged).
+   The package was removed including config (purged).
 
 
 EXAMPLES
@@ -52,36 +58,37 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Install foo and bar packages
-    __package_dpkg foo_0.1_all.deb --source /tmp/foo_0.1_all.deb
-    __package_dpkg bar_1.4.deb --source $__type/files/bar_1.4.deb
+   # Install foo and bar packages
+   __package_dpkg foo_0.1_all.deb --source /tmp/foo_0.1_all.deb
+   __package_dpkg bar_1.4.deb --source $__type/files/bar_1.4.deb
 
-    # uninstall baz:
-    __package_dpkg baz_1.4_amd64.deb \
-        --source $__type/files/baz_1.4_amd64.deb \
-        --state "absent"
-    # uninstall baz and also purge config-files:
-    __package_dpkg baz_1.4_amd64.deb \
-        --source $__type/files/baz_1.4_amd64.deb \
-        --purge-if-absent \
-        --state "absent"
+   # uninstall baz:
+   __package_dpkg baz_1.4_amd64.deb \
+       --source $__type/files/baz_1.4_amd64.deb \
+       --state "absent"
+   # uninstall baz and also purge config-files:
+   __package_dpkg baz_1.4_amd64.deb \
+       --source $__type/files/baz_1.4_amd64.deb \
+       --purge-if-absent \
+       --state "absent"
 
 
 SEE ALSO
 --------
-:strong:`cdist-type__package`\ (7), :strong:`dpkg-query`\ (1)
+* :strong:`cdist-type__package`\ (7)
+* :strong:`dpkg-query`\ (1)
 
 
 AUTHORS
 -------
-| Tomas Pospisek <tpo_deb--@--sourcepole.ch>
-| Thomas Eckert <tom--@--it-eckert.de>
+* Tomas Pospisek <tpo_deb--@--sourcepole.ch>
+* Thomas Eckert <tom--@--it-eckert.de>
 
 
 COPYING
 -------
-Copyright \(C) 2013 Tomas Pospisek. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
-This type is based on __package_apt.
+Copyright \(C) 2013 Tomas Pospisek.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.  This type is based on
+__package_apt.

--- a/type/__package_emerge/man.rst
+++ b/type/__package_emerge/man.rst
@@ -14,50 +14,55 @@ cdist-type__package_emerge_dependencies is supposed to install the needed
 packages on the target host.
 
 
-REQUIRED PARAMETERS
--------------------
-None
-
-
 OPTIONAL PARAMETERS
 -------------------
 name
-    If supplied, use the name and not the object id as the package name.
+   The name of the package to install.
 
+   Defaults to: ``__object_id``
 state
-    Either "present" or "absent", defaults to "present".
+   One of:
 
+   present
+      the package is installed
+   absent
+      the package is uninstalled
+
+   Defaults to: ``present``
 version
-    If supplied, use to install or uninstall a specific version of the package named.
+   If supplied, use to install or uninstall a specific version of the package
+   named.
+
 
 EXAMPLES
 --------
 
 .. code-block:: sh
 
-    # Ensure sys-devel/gcc is installed
-    __package_emerge sys-devel/gcc --state present
+   # Ensure sys-devel/gcc is installed
+   __package_emerge sys-devel/gcc --state present
 
-    # If you want a specific version of a package
-    __package_emerge app-portage/gentoolkit --state present --version 0.3.0.8-r2
+   # If you want a specific version of a package
+   __package_emerge app-portage/gentoolkit --state present --version 0.3.0.8-r2
 
-    # Remove package
-    __package_emerge sys-devel/gcc --state absent
+   # Remove package
+   __package_emerge sys-devel/gcc --state absent
 
 
 SEE ALSO
 --------
-:strong:`cdist-type__package`\ (7), :strong:`cdist-type__package_emerge_dependencies`\ (7)
+* :strong:`cdist-type__package`\ (7)
+* :strong:`cdist-type__package_emerge_dependencies`\ (7)
 
 
 AUTHORS
 -------
-Thomas Oettli <otho--@--sfs.biz>
+* Thomas Oettli <otho--@--sfs.biz>
 
 
 COPYING
 -------
-Copyright \(C) 2013 Thomas Oettli. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2013 Thomas Oettli.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__package_emerge_dependencies/man.rst
+++ b/type/__package_emerge_dependencies/man.rst
@@ -3,26 +3,18 @@ cdist-type__package_emerge_dependencies(7)
 
 NAME
 ----
-cdist-type__package_emerge_dependencies - Install dependencies for __package_emerge
+cdist-type__package_emerge_dependencies - Install dependencies for
+:strong:`cdist-type__package_emerge`\ (7)
 
 
 DESCRIPTION
 -----------
-Portage is usually used on the gentoo distribution to manage packages.
-This type installs the following tools which are required by __package_emerge to work:
+Portage is usually used on the Gentoo distribution to manage packages.
+This type installs the following tools which are required by
+:strong:`cdist-type__package_emerge`\ (7) to work:
 
 * app-portage/flaggie
 * app-portage/gentoolkit
-
-
-REQUIRED PARAMETERS
--------------------
-None
-
-
-OPTIONAL PARAMETERS
--------------------
-None
 
 
 EXAMPLES
@@ -30,23 +22,24 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Ensure app-portage/flaggie and app-portage/gentoolkit are installed
-    __package_emerge_dependencies
+   # Ensure app-portage/flaggie and app-portage/gentoolkit are installed
+   __package_emerge_dependencies
 
 
 SEE ALSO
 --------
-:strong:`cdist-type__package`\ (7), :strong:`cdist-type__package_emerge`\ (7)
+* :strong:`cdist-type__package`\ (7)
+* :strong:`cdist-type__package_emerge`\ (7)
 
 
 AUTHORS
 -------
-Thomas Oettli <otho--@--sfs.biz>
+* Thomas Oettli <otho--@--sfs.biz>
 
 
 COPYING
 -------
-Copyright \(C) 2013 Thomas Oettli. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2013 Thomas Oettli.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__package_luarocks/man.rst
+++ b/type/__package_luarocks/man.rst
@@ -11,18 +11,21 @@ DESCRIPTION
 LuaRocks is a deployment and management system for Lua modules.
 
 
-REQUIRED PARAMETERS
--------------------
-None
-
-
 OPTIONAL PARAMETERS
 -------------------
 name
-    If supplied, use the name and not the object id as the package name.
+   The name of the package to install.
 
+   Defaults to: ``__object_id``
 state
-    Either "present" or "absent", defaults to "present"
+   One of:
+
+   present
+      the package is installed
+   absent
+      the package is uninstalled
+
+   Defaults to: ``present``
 
 
 EXAMPLES
@@ -30,26 +33,27 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Ensure luasocket is installed
-    __package_luarocks luasocket --state present
+   # Ensure luasocket is installed
+   __package_luarocks luasocket --state present
 
-    # Remove package
-    __package_luarocks luasocket --state absent
+   # Remove package
+   __package_luarocks luasocket --state absent
 
 
 SEE ALSO
 --------
-:strong:`cdist-type__package`\ (7)
+* :strong:`cdist-type__package`\ (7)
+* `<https://luarocks.org/>`_
 
 
 AUTHORS
 -------
-Christian G. Warden <cwarden@xerus.org>
+* Christian G. Warden <cwarden@xerus.org>
 
 
 COPYING
 -------
-Copyright \(C) 2012 SwellPath, Inc. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2012 SwellPath, Inc.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__package_opkg/man.rst
+++ b/type/__package_opkg/man.rst
@@ -11,16 +11,10 @@ DESCRIPTION
 opkg is usually used on OpenWRT to manage packages.
 
 
-REQUIRED PARAMETERS
--------------------
-None
-
-
 OPTIONAL PARAMETERS
 -------------------
 name
    If supplied, use the name and not the object id as the package name.
-
 state
    Either "present" or "absent", defaults to "present"
 
@@ -30,26 +24,26 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Ensure lsof is installed
-    __package_opkg lsof --state present
+   # Ensure lsof is installed
+   __package_opkg lsof --state present
 
-    # Remove obsolete package
-    __package_opkg dnsmasq --state absent
+   # Remove obsolete package
+   __package_opkg dnsmasq --state absent
 
 
 SEE ALSO
 --------
-:strong:`cdist-type__package`\ (7)
+* :strong:`cdist-type__package`\ (7)
 
 
 AUTHORS
 -------
-Giel van Schijndel <giel+cdist--@--mortis.eu>
+* Giel van Schijndel <giel+cdist--@--mortis.eu>
 
 
 COPYING
 -------
-Copyright \(C) 2012 Giel van Schijndel. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2012 Giel van Schijndel.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__package_pacman/man.rst
+++ b/type/__package_pacman/man.rst
@@ -11,18 +11,21 @@ DESCRIPTION
 Pacman is usually used on the Archlinux distribution to manage packages.
 
 
-REQUIRED PARAMETERS
--------------------
-None
-
-
 OPTIONAL PARAMETERS
 -------------------
 name
-    If supplied, use the name and not the object id as the package name.
+   The name of the package to install.
 
+   Defaults to: ``__object_id``
 state
-    Either "present" or "absent", defaults to "present"
+   One of:
+
+   present
+      the package is installed
+   absent
+      the package is uninstalled
+
+   Defaults to: ``present``
 
 
 EXAMPLES
@@ -30,29 +33,29 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Ensure zsh in installed
-    __package_pacman zsh --state present
+   # Ensure zsh in installed
+   __package_pacman zsh --state present
 
-    # If you don't want to follow pythonX packages, but always use python
-    __package_pacman python --state present --name python2
+   # If you don't want to follow pythonX packages, but always use python
+   __package_pacman python --state present --name python2
 
-    # Remove obsolete package
-    __package_pacman puppet --state absent
+   # Remove obsolete package
+   __package_pacman puppet --state absent
 
 
 SEE ALSO
 --------
-:strong:`cdist-type__package`\ (7)
+* :strong:`cdist-type__package`\ (7)
 
 
 AUTHORS
 -------
-Nico Schottelius <nico-cdist--@--schottelius.org>
+* Nico Schottelius <nico-cdist--@--schottelius.org>
 
 
 COPYING
 -------
-Copyright \(C) 2011-2012 Nico Schottelius. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2011-2012 Nico Schottelius.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__package_pip/man.rst
+++ b/type/__package_pip/man.rst
@@ -20,45 +20,42 @@ Most OSes provide a package to get a default pip installation, so it's usually
 sufficient to add ``__package python3-pip`` to your manifest.
 
 
-REQUIRED PARAMETERS
--------------------
-None
-
-
 OPTIONAL PARAMETERS
 -------------------
-requirement
-    Can be anything supported by ``pip install`` - package name, URL, package
-    with extras etc.
-
 pip
-    Instead of using pip from ``PATH``, use the specified command to execute
-    pip.
-    The value to this parameter can be a path, executable name or a string of
-    the form ``pythonX.Y -m pip`` or ``/path/to/venv/bin/python -m pip``.
-
-state
-    Either ``present`` or ``absent``, defaults to ``present``.
-
+   Instead of using pip from ``PATH``, use the specified command to execute
+   pip.
+   The value to this parameter can be a path, executable name or a string of
+   the form ``pythonX.Y -m pip`` or ``/path/to/venv/bin/python -m pip``.
+requirement
+   Can be anything supported by ``pip install`` - package name, URL, package
+   with extras etc.
 runas
-    Run pip as specified user. By default it runs as root.
+   Run pip as specified user. By default it runs as root.
+state
+   One of:
+
+   present
+      the package is installed
+   absent
+      the package is uninstalled
+
+   Defaults to: ``present``
 
 
 DEPRECATED OPTIONAL PARAMETERS
 ------------------------------
-name
-    If supplied, use the name and not the object id as the package name.
-
 extra
-    Extra optional dependencies which should be installed along the selected
-    package. Can be specified multiple times. Multiple extras can be passed
-    in one ``--extra`` as a comma-separated list.
+   Extra optional dependencies which should be installed along the selected
+   package. Can be specified multiple times. Multiple extras can be passed
+   in one ``--extra`` as a comma-separated list.
 
-    Extra optional dependencies will be installed even when the base package
-    is already installed. Notice that the type will not remove installed extras
-    that are not explicitly named for the type because pip does not offer a
-    management for orphaned packages and they may be used by other packages.
-
+   Extra optional dependencies will be installed even when the base package
+   is already installed. Notice that the type will not remove installed extras
+   that are not explicitly named for the type because pip does not offer a
+   management for orphaned packages and they may be used by other packages.
+name
+   If supplied, use the name and not the object id as the package name.
 
 
 EXAMPLES
@@ -66,35 +63,40 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Install a package
-    __package_pip pyro --state present
+   # Install a package
+   __package_pip pyro --state present
 
-    # Use pip in a virtualenv located at /root/shinken_virtualenv
-    __package_pip pyro --state present --pip /root/shinken_virtualenv/bin/pip
+   # Use pip in a virtualenv located at /root/shinken_virtualenv
+   __package_pip pyro \
+      --state present --pip /root/shinken_virtualenv/bin/pip
 
-    # Use pip in a virtualenv located at /foo/shinken_virtualenv as user foo
-    __package_pip pyro --state present --pip /foo/shinken_virtualenv/bin/pip --runas foo
+   # Use pip in a virtualenv located at /foo/shinken_virtualenv as user foo
+   __package_pip pyro \
+      --state present --pip /foo/shinken_virtualenv/bin/pip --runas foo
 
-    # Install package with extras
-    __package_pip mautrix-telegram --requirement mautrix-telegram[speedups,webp_convert,hq_thumbnails]
+   # Install package with extras
+   __package_pip mautrix-telegram \
+      --requirement mautrix-telegram[speedups,webp_convert,hq_thumbnails]
 
-    # or take all extras
-    __package_pip mautrix-telegram --requirement mautrix-telegram[all]
+   # or take all extras
+   __package_pip mautrix-telegram \
+      --requirement mautrix-telegram[all]
 
-    # Install package from URL
-    __package_pip mkosi --requirement git+https://github.com/systemd/mkosi.git
+   # Install package from URL
+   __package_pip mkosi \
+      --requirement git+https://github.com/systemd/mkosi.git
 
 
 SEE ALSO
 --------
-:strong:`cdist-type__package`\ (7)
+* :strong:`cdist-type__package`\ (7)
 
 
 AUTHORS
 -------
-| Nico Schottelius <nico-cdist--@--schottelius.org>
-| Matthias Stecher <matthiasstecher--@--gmx.de>
-| Dennis Camera <cdist--@--dtnr.ch>
+* Nico Schottelius <nico-cdist--@--schottelius.org>
+* Matthias Stecher <matthiasstecher--@--gmx.de>
+* Dennis Camera <cdist--@--dtnr.ch>
 
 
 COPYING

--- a/type/__package_pkg_freebsd/man.rst
+++ b/type/__package_pkg_freebsd/man.rst
@@ -3,7 +3,7 @@ cdist-type__package_pkg_freebsd(7)
 
 NAME
 ----
-cdist-type__package_pkg_freebsd - Manage FreeBSD packages 
+cdist-type__package_pkg_freebsd - Manage FreeBSD packages
 
 
 DESCRIPTION
@@ -11,27 +11,27 @@ DESCRIPTION
 This type is usually used on FreeBSD to manage packages.
 
 
-REQUIRED PARAMETERS
--------------------
-None
-
-
 OPTIONAL PARAMETERS
 -------------------
-name
-    If supplied, use the name and not the object id as the package name.
-
 flavor
-    If supplied, use to avoid ambiguity.
+   If supplied, use to avoid ambiguity.
+name
+   The name of the package to install.
 
-version
-    If supplied, use to install a specific version of the package named.
-
+   Defaults to: ``__object_id``
 pkgsite
-    If supplied, use to install from a specific package repository.
-
+   If supplied, use to install from a specific package repository.
 state
-    Either "present" or "absent", defaults to "present"
+   One of:
+
+   present
+      the package is installed
+   absent
+      the package is uninstalled
+
+   Defaults to: ``present``
+version
+   If supplied, use to install a specific version of the package named.
 
 
 EXAMPLES
@@ -39,32 +39,32 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Ensure zsh is installed
-    __package_pkg_freebsd zsh --state present
+   # Ensure zsh is installed
+   __package_pkg_freebsd zsh --state present
 
-    # Ensure vim is installed, use flavor no_x11
-    __package_pkg_freebsd vim --state present --flavor no_x11
+   # Ensure vim is installed, use flavor no_x11
+   __package_pkg_freebsd vim --state present --flavor no_x11
 
-    # If you don't want to follow pythonX packages, but always use python
-    __package_pkg_freebsd python --state present --name python2
+   # If you don't want to follow pythonX packages, but always use python
+   __package_pkg_freebsd python --state present --name python2
 
-    # Remove obsolete package
-    __package_pkg_freebsd puppet --state absent
+   # Remove obsolete package
+   __package_pkg_freebsd puppet --state absent
 
 
 SEE ALSO
 --------
-:strong:`cdist-type__package`\ (7)
+* :strong:`cdist-type__package`\ (7)
 
 
 AUTHORS
 -------
-Jake Guffey <jake.guffey--@--eprotex.com>
+* Jake Guffey <jake.guffey--@--eprotex.com>
 
 
 COPYING
 -------
-Copyright \(C) 2012 Jake Guffey. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2012 Jake Guffey.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__package_pkg_openbsd/man.rst
+++ b/type/__package_pkg_openbsd/man.rst
@@ -11,61 +11,64 @@ DESCRIPTION
 This type is usually used on OpenBSD to manage packages.
 
 
-REQUIRED PARAMETERS
--------------------
-None
-
-
 OPTIONAL PARAMETERS
 -------------------
-name
-    If supplied, use the name and not the object id as the package name.
-
 flavor
-    If supplied, use to avoid ambiguity.
+   If supplied, use to avoid ambiguity.
+name
+   The name of the package to install.
 
-version
-    If supplied, use to avoid ambiguity.
-
-state
-    Either "present" or "absent", defaults to "present"
-
+   Defaults to: ``__object_id``
 pkg_path
-    Manually specify a PKG_PATH to add packages from.
+   Manually specify a PKG_PATH to add packages from.
+state
+   One of:
+
+   present
+      the package is installed
+   absent
+      the package is uninstalled
+
+   Defaults to: ``present``
+version
+   If supplied, use to avoid ambiguity.
+
 
 EXAMPLES
 --------
 
 .. code-block:: sh
 
-    # Ensure zsh is installed
-    __package_pkg_openbsd zsh --state present
+   # Ensure zsh is installed
+   __package_pkg_openbsd zsh --state present
 
-    # Ensure vim is installed, use flavor no_x11
-    __package_pkg_openbsd vim --state present --flavor no_x11
+   # Ensure vim is installed, use flavor no_x11
+   __package_pkg_openbsd vim --state present --flavor no_x11
 
-    # If you don't want to follow pythonX packages, but always use python
-    __package_pkg_openbsd python --state present --name python2
+   # If you don't want to follow pythonX packages, but always use python
+   __package_pkg_openbsd python --state present --name python2
 
-    # Remove obsolete package
-    __package_pkg_openbsd puppet --state absent
+   # Remove obsolete package
+   __package_pkg_openbsd puppet --state absent
 
-    # Add a package using a particular mirror
-    __package_pkg_openbsd bash \
-      --pkg_path http://openbsd.mirrorcatalogs.com/snapshots/packages/amd64
+   # Add a package using a particular mirror
+   __package_pkg_openbsd bash \
+     --pkg_path http://openbsd.mirrorcatalogs.com/snapshots/packages/amd64
 
 
 SEE ALSO
 --------
-:strong:`cdist-type__package`\ (7)
+* :strong:`cdist-type__package`\ (7)
 
 
 AUTHORS
 -------
-Andi Brönnimann <andi-cdist--@--v-net.ch>
+* Andi Brönnimann <andi-cdist--@--v-net.ch>
 
 
 COPYING
 -------
-Copyright \(C) 2011 Andi Brönnimann. Free use of this software is
-granted under the terms of the GNU General Public License version 3 (GPLv3).
+Copyright \(C) 2011 Andi Brönnimann.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__package_pkgng_freebsd/man.rst
+++ b/type/__package_pkgng_freebsd/man.rst
@@ -11,43 +11,33 @@ DESCRIPTION
 This type is usually used on FreeBSD to manage packages.
 
 
-REQUIRED PARAMETERS
--------------------
-None
-
-
 OPTIONAL PARAMETERS
 -------------------
-name
-    If supplied, use the name and not the object id as the package name.
-
 flavor
-    If supplied, use to avoid ambiguity.
+   If supplied, use to avoid ambiguity.
+name
+   The name of the package to install.
 
-version
-    If supplied, use to install a specific version of the package named.
-
+   Defaults to: ``__object_id``
 repo
-    If supplied, use to install the package named from a particular repo.
-
+   If supplied, use to install the package named from a particular repo.
 state
-    Either "present" or "absent", defaults to "present"
+   One of:
+
+   present
+      the package is installed
+   absent
+      the package is uninstalled
+
+   Defaults to: ``present``
+version
+   If supplied, use to install a specific version of the package named.
 
 
 BOOLEAN PARAMETERS
 ------------------
 upgrade
-    If supplied, allow upgrading to the latest version of a package.
-
-
-CAVEATS
--------
-This type requires that repository definitions already exist in /etc/pkg/\*.conf.
-Ensure that they exist prior to use of this type with __file.
-
-pkg-ng can't upgrade a package to a specific version. If this type needs to
-upgrade a package, it can only ugprade to the latest available version. If the
-"upgrade" parameter is not given and an upgrade needs to occur, an error will result.
+   If supplied, allow upgrading to the latest version of a package.
 
 
 MESSAGES
@@ -67,35 +57,48 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Ensure zsh is installed
-    __package_pkgng_freebsd zsh --state present
+   # Ensure zsh is installed
+   __package_pkgng_freebsd zsh --state present
 
-    # Ensure vim is installed, use flavor no_x11
-    __package_pkgng_freebsd vim --state present --flavor no_x11
+   # Ensure vim is installed, use flavor no_x11
+   __package_pkgng_freebsd vim --state present --flavor no_x11
 
-    # If you don't want to follow pythonX packages, but always use python
-    __package_pkgng_freebsd python --state present --name python2
+   # If you don't want to follow pythonX packages, but always use python
+   __package_pkgng_freebsd python --state present --name python2
 
-    # Install a package from a particular repository when multiples exist
-    __package_pkgng_freebsd bash --state present --repo myrepo
+   # Install a package from a particular repository when multiples exist
+   __package_pkgng_freebsd bash --state present --repo myrepo
 
-    # Remove obsolete package
-    __package_pkgng_freebsd puppet --state absent
+   # Remove obsolete package
+   __package_pkgng_freebsd puppet --state absent
+
+
+CAVEATS
+-------
+This type requires that repository definitions already exist in
+``/etc/pkg/\*.conf``.
+Ensure that they exist prior to use of this type with
+:strong:`cdist-type__file`\ (7).
+
+pkg-ng can't upgrade a package to a specific version. If this type needs to
+upgrade a package, it can only ugprade to the latest available version. If the
+"upgrade" parameter is not given and an upgrade needs to occur, an error will
+result.
 
 
 SEE ALSO
 --------
-:strong:`cdist-type__package`\ (7)
+* :strong:`cdist-type__package`\ (7)
 
 
 AUTHORS
 -------
-Jake Guffey <jake.guffey--@--eprotex.com>
+* Jake Guffey <jake.guffey--@--eprotex.com>
 
 
 COPYING
 -------
-Copyright \(C) 2014 Jake Guffey. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2014 Jake Guffey.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__package_rubygem/man.rst
+++ b/type/__package_rubygem/man.rst
@@ -8,21 +8,25 @@ cdist-type__package_rubygem - Manage rubygem packages
 
 DESCRIPTION
 -----------
-Rubygems is the default package management system for the Ruby programming language.
-
-
-REQUIRED PARAMETERS
--------------------
-None
+Rubygems is the default package management system for the Ruby programming
+language.
 
 
 OPTIONAL PARAMETERS
 -------------------
 name
-    If supplied, use the name and not the object id as the package name.
+   The name of the package to install.
 
+   Defaults to: ``__object_id``
 state
-    Either "present" or "absent", defaults to "present"
+   One of:
+
+   present
+      the package is installed
+   absent
+      the package is uninstalled
+
+   Defaults to: ``present``
 
 
 EXAMPLES
@@ -30,27 +34,27 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Ensure sinatra is installed
-    __package_rubygem sinatra --state present
+   # Ensure sinatra is installed
+   __package_rubygem sinatra --state present
 
-    # Remove package
-    __package_rubygem rails --state absent
+   # Remove package
+   __package_rubygem rails --state absent
 
 
 SEE ALSO
 --------
-:strong:`cdist-type__package`\ (7)
+* :strong:`cdist-type__package`\ (7)
+* `<https://rubygems.org/>`_
 
 
 AUTHORS
 -------
-Chase Allen James <nx-cdist@nu-ex.com>
+* Chase Allen James <nx-cdist@nu-ex.com>
 
 
 COPYING
 -------
-
-Copyright \(C) 2011 Chase Allen James. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2011 Chase Allen James.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__package_yum/man.rst
+++ b/type/__package_yum/man.rst
@@ -13,20 +13,23 @@ If you specify an unknown package, yum will display the
 slightly confusing error message "Error: Nothing to do".
 
 
-REQUIRED PARAMETERS
--------------------
-None
-
-
 OPTIONAL PARAMETERS
 -------------------
 name
-    If supplied, use the name and not the object id as the package name.
+   The name of the package to install.
 
+   Defaults to: ``__object_id``
 state
-    Either "present" or "absent", defaults to "present"
+   One of:
+
+   present
+      the package is installed
+   absent
+      the package is uninstalled
+
+   Defaults to: ``present``
 url
-    URL to use for the package
+   URL to use for the package
 
 
 EXAMPLES
@@ -34,32 +37,32 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Ensure zsh in installed
-    __package_yum zsh --state present
+   # Ensure zsh in installed
+   __package_yum zsh --state present
 
-    # If you don't want to follow pythonX packages, but always use python
-    __package_yum python --state present --name python2
+   # If you don't want to follow pythonX packages, but always use python
+   __package_yum python --state present --name python2
 
-    # Remove obsolete package
-    __package_yum puppet --state absent
+   # Remove obsolete package
+   __package_yum puppet --state absent
 
-    __package epel-release-6-8 \
-        --url http://mirror.switch.ch/ftp/mirror/epel/6/i386/epel-release-6-8.noarch.rpm
+   __package epel-release-6-8 \
+       --url http://mirror.switch.ch/ftp/mirror/epel/6/i386/epel-release-6-8.noarch.rpm
 
 
 SEE ALSO
 --------
-:strong:`cdist-type__package`\ (7)
+* :strong:`cdist-type__package`\ (7)
 
 
 AUTHORS
 -------
-Nico Schottelius <nico-cdist--@--schottelius.org>
+* Nico Schottelius <nico-cdist--@--schottelius.org>
 
 
 COPYING
 -------
-Copyright \(C) 2011-2012 Nico Schottelius. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2011-2012 Nico Schottelius.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__package_zypper/man.rst
+++ b/type/__package_zypper/man.rst
@@ -11,26 +11,30 @@ DESCRIPTION
 Zypper is usually used on the SuSE distribution to manage packages.
 
 
-REQUIRED PARAMETERS
--------------------
-None
-
-
 OPTIONAL PARAMETERS
 -------------------
 name
-    If supplied, use the name and not the object id as the package name.
+   The name of the package to install.
 
-state
-    Either "present" or "absent", defaults to "present"
-
-version
-    The version of the package to install. Default is to install the version
-    chosen by the local package manager. For a list of available versions,
-    have a look at the output of "zypper se -s packagename"
-
+   Defaults to: ``__object_id``
 ptype
-    Either "package", "patch", "pattern", "product" or "srcpackage", defaults to "package". For a description see man zypper.
+   Either "package", "patch", "pattern", "product", or "srcpackage".
+   For a description see :strong:`zypper`\ (8).
+
+   Defaults to: ``package``
+state
+   One of:
+
+   present
+      the package is installed
+   absent
+      the package is uninstalled
+
+   Defaults to: ``present``
+version
+   The version of the package to install. Default is to install the version
+   chosen by the local package manager. For a list of available versions,
+   have a look at the output of "zypper se -s packagename"
 
 
 EXAMPLES
@@ -38,36 +42,37 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Ensure zsh is installed
-    __package_zypper zsh --state present
+   # Ensure zsh is installed
+   __package_zypper zsh --state present
 
-    # If you don't want to follow pythonX packages, but always use python
-    __package_zypper python --state present --name python2
+   # If you don't want to follow pythonX packages, but always use python
+   __package_zypper python --state present --name python2
 
-    # Ensure binutils is installed and the version is forced to be 2.23.1-0.19.2
-    __package_zypper binutils --state present --version 2.23.1-0.19.2
+   # Ensure binutils is installed and the version is forced to be 2.23.1-0.19.2
+   __package_zypper binutils --state present --version 2.23.1-0.19.2
 
-    # Remove package
-    __package_zypper cfengine --state absent
+   # Remove package
+   __package_zypper cfengine --state absent
 
-    # install all packages which belongs to pattern x11
-    __package_zypper x11 --ptype pattern --state present
+   # install all packages which belongs to pattern x11
+   __package_zypper x11 --ptype pattern --state present
 
 
 SEE ALSO
 --------
-:strong:`cdist-type__package`\ (7)
+* :strong:`cdist-type__package`\ (7)
+* :strong:`zypper`\ (8)
 
 
 AUTHORS
 -------
-Daniel Heule <hda--@--sfs.biz>
+* Nico Schottelius <nico-cdist--@--schottelius.org>
+* Daniel Heule <hda--@--sfs.biz>
 
 
 COPYING
 -------
-Copyright \(C) 2012 Nico Schottelius.
-Copyright \(C) 2013 Daniel Heule.
+Copyright \(C) 2012 Nico Schottelius, 2013 Daniel Heule.
 You can redistribute it and/or modify it under the terms of the
 GNU General Public License as published by the Free Software Foundation,
 either version 3 of the License, or (at your option) any later version.

--- a/type/__pacman_conf/man.rst
+++ b/type/__pacman_conf/man.rst
@@ -8,37 +8,37 @@ cdist-type__pacman_conf - Manage pacman configuration
 
 DESCRIPTION
 -----------
-The type allows you to configure options section, add or delete repositories and manage mirrorlists
+The type allows you to configure options section, add or delete repositories and
+manage mirrorlists.
 
 
 REQUIRED PARAMETERS
 -------------------
-section
-    'options' for configure options section
-
-    Otherwise it specifies a repository or a plain file
-
 key
-    Specifies the key which will be set
+   Specifies the key which will be set
 
-    If section = 'options' or file is not set the key will
-    be checked against available keys from pacman.conf
+   If section = 'options' or file is not set the key will
+   be checked against available keys from pacman.conf
+section
+   'options' for configure options section
 
+   Otherwise it specifies a repository or a plain file
 value
-    Specifies the value which will be set against the key
+   Specifies the value which will be set against the key
 
 
 OPTIONAL PARAMETERS
 -------------------
-state
-    'present' or 'absent', defaults to 'present'
-
 file
-    Specifies the filename.
+   Specifies the filename.
 
-    The managed file will be named like 'plain_file_filename'
+   The managed file will be named like 'plain_file_filename'
 
-    If supplied the key will not be checked.
+   If supplied the key will not be checked.
+state
+   ``present`` or ``absent``.
+
+   Defaults to: ``present``
 
 
 EXAMPLES
@@ -46,30 +46,39 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Manage options section in pacman.conf
-    __pacman_conf options_Architecture --section options --key Architecture --value auto
+   # Manage options section in pacman.conf
+   __pacman_conf options_Architecture \
+      --section options \
+      --key Architecture \
+      --value auto
 
-    # Add new repository
-    __pacman_conf localrepo_Server --section localrepo --key Server --value "file:///var/cache/pacman/pkg"
+   # Add new repository
+   __pacman_conf localrepo_Server \
+      --section localrepo \
+      --key Server
+      --value 'file:///var/cache/pacman/pkg'
 
-    # Add mirror to a mirrorlist
-    __pacman_conf customlist_Server --file customlist --section customlist --key Server\
-        --value "file:///var/cache/pacman/pkg"
+   # Add mirror to a mirrorlist
+   __pacman_conf customlist_Server \
+      --file customlist \
+      --section customlist \
+      --key Server\
+      --value 'file:///var/cache/pacman/pkg'
 
 
 SEE ALSO
 --------
-:strong:`grep`\ (1)
+* :strong:`grep`\ (1)
 
 
 AUTHORS
 -------
-Dominique Roux <dominique.roux4@gmail.com>
+* Dominique Roux <dominique.roux4@gmail.com>
 
 
 COPYING
 -------
-Copyright \(C) 2015 Dominique Roux. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2015 Dominique Roux.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__pacman_conf_integrate/man.rst
+++ b/type/__pacman_conf_integrate/man.rst
@@ -3,22 +3,22 @@ cdist-type__pacman_conf_integrate(7)
 
 NAME
 ----
-cdist-type__pacman_conf_integrate - Integrate default pacman.conf to cdist conform and vice versa
+cdist-type__pacman_conf_integrate - Integrate default ``pacman.conf`` to a cdist
+conformant one and vice versa.
 
 
 DESCRIPTION
 -----------
-The type allows you to convert the default pacman.conf to a cdist conform one and vice versa
+The type allows you to convert the default ``pacman.conf`` to a cdist conformant
+one and vice versa
 
-
-REQUIRED PARAMETERS
--------------------
-None.
 
 OPTIONAL PARAMETERS
 -------------------
 state
-    'present' or 'absent', defaults to 'present'
+   ``present`` or ``absent``.
+
+   Defaults to: ``present``
 
 
 EXAMPLES
@@ -26,26 +26,26 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Convert normal to cdist conform
-    __pacman_conf_integrate convert
+   # Convert normal to cdist conform
+   __pacman_conf_integrate convert
 
-    # Convert cdist conform to normal
-    __pacman_conf_integrate convert --state absent
+   # Convert cdist conform to normal
+   __pacman_conf_integrate convert --state absent
 
 
 SEE ALSO
 --------
-:strong:`grep`\ (1)
+* :strong:`grep`\ (1)
 
 
 AUTHORS
 -------
-Dominique Roux <dominique.roux4@gmail.com>
+* Dominique Roux <dominique.roux4@gmail.com>
 
 
 COPYING
 -------
-Copyright \(C) 2015 Dominique Roux. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2015 Dominique Roux.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__pyvenv/man.rst
+++ b/type/__pyvenv/man.rst
@@ -14,40 +14,49 @@ It assumes pyvenv is already installed. Concrete package depends
 on concrete OS and/or OS version/distribution.
 Ensure this for e.g. in your init manifest as in the following example:
 
-.. code-block sh
+.. code-block:: sh
 
-    case "$__target_host" in
-        localhost)
-            __package python3-venv --state present
-            require="__package/python3-venv" __pyvenv /home/darko/testenv --pyvenv "pyvenv-3.4" --owner darko --group darko --mode 740 --state present
-            require="__pyvenv/home/darko/testenv" __package_pip docopt --pip /home/darko/testenv/bin/pip --runas darko --state present
-        ;;
-    esac
+   case ${__target_host:?}
+   in
+      (localhost)
+         __package python3-venv --state present
+         require=__package/python3-venv \
+         __pyvenv /home/darko/testenv \
+            --pyvenv pyvenv-3.4 \
+            --owner darko --group darko --mode 740 \
+            --state present
+         require=__pyvenv/home/darko/testenv \
+         __package_pip docopt \
+            --pip /home/darko/testenv/bin/pip \
+            --runas darko \
+            --state present
+         ;;
+   esac
 
-
-REQUIRED PARAMETERS
--------------------
-None
 
 OPTIONAL PARAMETERS
 -------------------
-state
-    Either "present" or "absent", defaults to "present"
-
 group
-   Group to chgrp to
+   Group to :strong:`chgrp`\ (1) to.
+interpreter
+   Name or path of the interpreter to use for creating the venv.
 
+   Defaults to: ``python3``
 mode
    Unix permissions, suitable for chmod
-
 owner
-   User to chown to
+   User to :strong:`chown`\ (1) to
+state
+   One of:
 
+   present
+      the pyvenv exists
+   absent
+      the pyvenv does not exists
+
+   Defaults to: ``present``
 venvparams
    Specific parameters to pass to pyvenv invocation
-
-interpreter
-   Name or path of the interpreter to use for creating the venv (default to ``python3``)
 
 
 EXAMPLES
@@ -55,27 +64,30 @@ EXAMPLES
 
 .. code-block:: sh
 
-    __pyvenv /home/services/djangoenv
+   __pyvenv /home/services/djangoenv
 
-    # Use specific interpreter name
-    __pyvenv /home/foo/fooenv --interpreter python3.10
+   # Use specific interpreter name
+   __pyvenv /home/foo/fooenv --interpreter python3.10
 
-    # Use specific interpreter path
-    __pyvenv /home/foo/fooenv --interpreter /opt/python/3.4/bin/python3
+   # Use specific interpreter path
+   __pyvenv /home/foo/fooenv --interpreter /opt/python/3.4/bin/python3
 
-    # Create python virtualenv for user foo.
-    __pyvenv /home/foo/fooenv --group foo --owner foo
+   # Create python virtualenv for user foo.
+   __pyvenv /home/foo/fooenv --group foo --owner foo
 
-    # Create python virtualenv with specific parameters.
-    __pyvenv /home/services/djangoenv --venvparams "--copies --system-site-packages"
+   # Create python virtualenv with specific parameters.
+   __pyvenv /home/services/djangoenv \
+      --venvparams '--copies --system-site-packages'
 
 
 AUTHORS
 -------
-Darko Poljak <darko.poljak--@--gmail.com>
+* Darko Poljak <darko.poljak--@--gmail.com>
 
 
 COPYING
 -------
-Copyright \(C) 2016 Darko Poljak. Free use of this software is
-granted under the terms of the GNU General Public License v3 or later (GPLv3+).
+Copyright \(C) 2016 Darko Poljak.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__rsync/man.rst
+++ b/type/__rsync/man.rst
@@ -8,42 +8,17 @@ cdist-type__rsync - Mirror directories using ``rsync``
 
 DESCRIPTION
 -----------
-The purpose of this type is to bring power of ``rsync`` into ``cdist``.
+The purpose of this type is to bring power of :strong:`rsync`\ (1) into
+:strong:`skonfig`\ (1).
 
 
 REQUIRED PARAMETERS
 -------------------
 source
-   Source directory in local machine.
-   If source is directory, slash (``/``) will be added to source and destination paths.
+   Source directory on the local machine.
 
-
-OPTIONAL PARAMETERS
--------------------
-destination
-   Destination directory. Defaults to ``$__object_id``.
-
-owner
-   Will be passed to ``rsync`` as ``--chown=OWNER``.
-   Read ``rsync(1)`` for more details.
-
-group
-   Will be passed to ``rsync`` as ``--chown=:GROUP``.
-   Read ``rsync(1)`` for more details.
-
-mode
-   Will be passed to ``rsync`` as ``--chmod=MODE``.
-   Read ``rsync(1)`` for more details.
-
-options
-   Defaults to ``--recursive --links --perms --times``.
-   Due to `bug in Python's argparse<https://bugs.python.org/issue9334>`_, value must be prefixed with ``\``.
-
-remote-user
-   Defaults to ``root``.
-
-onchange
-   Command to run in target after sync.
+   If ``--source`` is a directory, a slash (``/``) will be added to source and
+   destination paths.
 
 
 OPTIONAL MULTIPLE PARAMETERS
@@ -51,7 +26,35 @@ OPTIONAL MULTIPLE PARAMETERS
 option
    Pass additional options to ``rsync``.
    See ``rsync(1)`` for all possible options.
-   Due to `bug in Python's argparse<https://bugs.python.org/issue9334>`_, value must be prefixed with ``\``.
+
+   Due to a `bug in Python's argparse<https://bugs.python.org/issue9334>`_,
+   the value must be prefixed with ``\``.
+
+
+OPTIONAL PARAMETERS
+-------------------
+destination
+   Destination directory.
+
+   Defaults to: ``__object_id``
+group
+   Will be passed to ``rsync`` as ``--chown=:GROUP``.
+   Read :strong:`rsync`\ (1) for more details.
+mode
+   Will be passed to ``rsync`` as ``--chmod=MODE``.
+   Read :strong:`rsync`\ (1) for more details.
+onchange
+   Command to run in target after sync.
+options
+   Defaults to: ``--recursive --links --perms --times``
+
+   Due to a `bug in Python's argparse<https://bugs.python.org/issue9334>`_,
+   the value must be prefixed with ``\``.
+owner
+   Will be passed to ``rsync`` as ``--chown=OWNER``.
+   Read :strong:`rsync`\ (1) for more details.
+remote-user
+   Defaults to: ``root``
 
 
 MESSAGES
@@ -62,23 +65,24 @@ synced
 
 EXAMPLES
 --------
+
 .. code-block:: sh
 
-    __rsync /var/www/example.com \
-        --owner root \
-        --group www-data \
-        --mode 'D750,F640' \
-        --source "$__files/example.com/www"
+   __rsync /var/www/example.com \
+      --owner root \
+      --group www-data \
+      --mode 'D750,F640' \
+      --source "${__files:?}/example.com/www"
 
 
 AUTHORS
 -------
-Ander Punnar <ander-at-kvlt-dot-ee>
+* Ander Punnar <ander-at-kvlt-dot-ee>
 
 
 COPYING
 -------
-Copyright \(C) 2021 Ander Punnar. You can redistribute it and/or modify it
-under the terms of the GNU General Public License as published by the Free
-Software Foundation, either version 3 of the License, or (at your option)
-any later version.
+Copyright \(C) 2021 Ander Punnar.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__sed/man.rst
+++ b/type/__sed/man.rst
@@ -22,7 +22,6 @@ OPTIONAL PARAMETERS
 -------------------
 file
    Path to the file. Defaults to ``$__object_id``.
-
 onchange
    Execute this command if ``sed`` changes file.
 
@@ -46,12 +45,12 @@ EXAMPLES
 
 AUTHORS
 -------
-Ander Punnar <ander-at-kvlt-dot-ee>
+* Ander Punnar <ander-at-kvlt-dot-ee>
 
 
 COPYING
 -------
-Copyright \(C) 2021 Ander Punnar. You can redistribute it and/or modify it
-under the terms of the GNU General Public License as published by the Free
-Software Foundation, either version 3 of the License, or (at your option)
-any later version.
+Copyright \(C) 2021 Ander Punnar.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__sensible_editor/man.rst
+++ b/type/__sensible_editor/man.rst
@@ -15,24 +15,26 @@ a given user.
 REQUIRED PARAMETERS
 -------------------
 editor
-    Name or path of the editor to be selected.
-    On systems other than Debian derivatives an absolute path is required.
+   Name or path of the editor to be selected.
+   On systems other than Debian derivatives an absolute path is required.
 
-    It is permissible to omit this parameter if --state is absent.
+   It is permissible to omit this parameter if ``--state absent``.
 
 
 OPTIONAL PARAMETERS
 -------------------
 state
-    'present', 'absent', or 'exists'. Defaults to 'present', where:
+   One of:
 
-    present
-        the sensible-editor is exactly what is specified in --editor.
-    absent
-        no sensible-editor configuration is present.
-    exists
-        the sensible-editor will be set to what is specified in --editor,
-        unless there already is a configuration on the target system.
+   present
+      the sensible-editor is exactly what is specified in --editor.
+   absent
+      no sensible-editor configuration is present.
+   exists
+      the sensible-editor will be set to what is specified in --editor,
+      unless there already is a configuration on the target system.
+
+   Defaults to: ``present``
 
 
 EXAMPLES
@@ -40,13 +42,12 @@ EXAMPLES
 
 .. code-block:: sh
 
-    __sensible_editor root --editor /bin/ed  # ed(1) is the standard
-    __sensible_editor noob --editor nano
+   __sensible_editor root --editor /bin/ed  # ed(1) is the standard
+   __sensible_editor noob --editor nano
 
 
 LIMITATIONS
 -----------
-
 This type depends upon the :strong:`sensible-editor`\ (1) script which
 is part of the sensible-utils package.
 
@@ -61,14 +62,16 @@ Therefore, the following operating systems are supported:
 Note: on old versions of Ubuntu the sensible-* utils are part of the
 debianutils package.
 
+
 SEE ALSO
 --------
-:strong:`select-editor`\ (1), :strong:`sensible-editor`\ (1).
+* :strong:`select-editor`\ (1)
+* :strong:`sensible-editor`\ (1)
 
 
-AUTHOR
+AUTHORS
 -------
-Dennis Camera <dennis.camera--@--ssrq-sds-fds.ch>
+* Dennis Camera <dennis.camera--@--ssrq-sds-fds.ch>
 
 
 COPYING

--- a/type/__ssh_authorized_key/man.rst
+++ b/type/__ssh_authorized_key/man.rst
@@ -3,20 +3,21 @@ cdist-type__ssh_authorized_key(7)
 
 NAME
 ----
-cdist-type__ssh_authorized_key - Manage a single ssh authorized key entry
+cdist-type__ssh_authorized_key - Manage a single SSH authorized key entry
 
 
 DESCRIPTION
 -----------
-Manage a single authorized key entry in an authorized_key file.
-This type was created to be used by the __ssh_authorized_keys type.
+Manage a single authorized key entry in an ``authorized_keys`` file.
+
+This type was created to be used by
+:strong:`cdist-type__ssh_authorized_keys`\ (7).
 
 
 REQUIRED PARAMETERS
 -------------------
 file
    The authorized_keys file where the given key should be managed.
-
 key
    The ssh key which shall be managed in this authorized_keys file.
    Must be a string containing the ssh keytype, base 64 encoded key and
@@ -28,21 +29,25 @@ OPTIONAL PARAMETERS
 -------------------
 comment
    Use this comment instead of the one which may be trailing in the key.
-
 option
    An option to set for this authorized_key entry.
    Can be specified multiple times.
-   See sshd(8) for available options.
-
+   See :strong:`sshd`\ (8) for available options.
 state
-   If the managed key should be 'present' or 'absent', defaults to 'present'.
+   One of:
+
+   present
+      the SSH public key is authorized to connect
+   absent
+      the SSH public key is not authorized to connect
+
+   Defaults to: ``present``
 
 
 MESSAGES
 --------
 added to `file` (`entry`)
    The key `entry` (with optional comment) was added to `file`.
-
 removed from `file` (`entry`)
    The key `entry` (with optional comment) was removed from `file`.
 
@@ -52,31 +57,32 @@ EXAMPLES
 
 .. code-block:: sh
 
-    __ssh_authorized_key some-id \
-       --file "/home/user/.ssh/autorized_keys" \
-       --key "$(cat ~/.ssh/id_rsa.pub)"
+   __ssh_authorized_key some-id \
+      --file /home/user/.ssh/autorized_keys \
+      --key "$(cat ~/.ssh/id_rsa.pub)"
 
-    __ssh_authorized_key some-id \
-       --file "/home/user/.ssh/autorized_keys" \
-       --key "$(cat ~/.ssh/id_rsa.pub)" \
-       --option 'command="/path/to/script"' \
-       --option 'environment="FOO=bar"' \
-       --comment 'one to rule them all'
+   __ssh_authorized_key some-id \
+      --file /home/user/.ssh/autorized_keys \
+      --key "$(cat ~/.ssh/id_rsa.pub)" \
+      --option 'command="/path/to/script"' \
+      --option 'environment="FOO=bar"' \
+      --comment 'one to rule them all'
 
 
 SEE ALSO
 --------
-:strong:`cdist-type__ssh_authorized_keys`\ (7), :strong:`sshd`\ (8)
+* :strong:`cdist-type__ssh_authorized_keys`\ (7)
+* :strong:`sshd`\ (8)
 
 
 AUTHORS
 -------
-Steven Armstrong <steven-cdist--@--armstrong.cc>
+* Steven Armstrong <steven-cdist--@--armstrong.cc>
 
 
 COPYING
 -------
-Copyright \(C) 2014 Steven Armstrong. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2014 Steven Armstrong.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__ssh_authorized_keys/man.rst
+++ b/type/__ssh_authorized_keys/man.rst
@@ -34,32 +34,26 @@ OPTIONAL PARAMETERS
 -------------------
 comment
    Use this comment instead of the one which may be trailing in each key.
-
 file
    An alternative destination file, defaults to ~$owner/.ssh/authorized_keys.
-
 option
    An option to set for all authorized_key entries in the key parameter.
    Can be specified multiple times.
    See sshd(8) for available options.
-
 owner
    The user owning the authorized_keys file, defaults to object_id.
-
 state
    If the given keys should be 'present' or 'absent', defaults to 'present'.
 
 
 BOOLEAN PARAMETERS
 ------------------
-noparent
-   Don't create or change ownership and permissions of the directory containing
-   the authorized_keys file.
-
 nofile
    Don't manage existence, ownership and permissions of the the authorized_keys
    file.
-
+noparent
+   Don't create or change ownership and permissions of the directory containing
+   the authorized_keys file.
 remove-unknown
    Remove undefined keys.
 
@@ -69,65 +63,65 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # add your ssh key to remote root's authorized_keys file
-    __ssh_authorized_keys root \
-       --key "$(cat ~/.ssh/id_rsa.pub)"
+   # add your ssh key to remote root's authorized_keys file
+   __ssh_authorized_keys root \
+      --key "$(cat ~/.ssh/id_rsa.pub)"
 
-    # same as above, but make sure your key is only key in
-    # root's authorized_keys file
-    __ssh_authorized_keys root \
-       --key "$(cat ~/.ssh/id_rsa.pub)" \
-       --remove-unknown
+   # same as above, but make sure your key is only key in
+   # root's authorized_keys file
+   __ssh_authorized_keys root \
+      --key "$(cat ~/.ssh/id_rsa.pub)" \
+      --remove-unknown
 
-    # allow key to login as user-name
-    __ssh_authorized_keys user-name \
-       --key "ssh-rsa AXYZAAB3NzaC1yc2..."
+   # allow key to login as user-name
+   __ssh_authorized_keys user-name \
+      --key "ssh-rsa AXYZAAB3NzaC1yc2..."
 
-    # allow key to login as user-name with options and expicit comment
-    __ssh_authorized_keys user-name \
-       --key "ssh-rsa AXYZAAB3NzaC1yc2..." \
-       --option no-agent-forwarding \
-       --option 'from="*.example.com"' \
-       --comment 'backup server'
+   # allow key to login as user-name with options and expicit comment
+   __ssh_authorized_keys user-name \
+      --key "ssh-rsa AXYZAAB3NzaC1yc2..." \
+      --option no-agent-forwarding \
+      --option 'from="*.example.com"' \
+      --comment 'backup server'
 
-    # same as above, but with explicit owner and two keys
-    # note that the options are set for all given keys
-    __ssh_authorized_keys some-fancy-id \
-       --owner user-name \
-       --key "ssh-rsa AXYZAAB3NzaC1yc2..." \
-       --key "ssh-rsa AZXYAAB3NzaC1yc2..." \
-       --option no-agent-forwarding \
-       --option 'from="*.example.com"' \
-       --comment 'backup server'
+   # same as above, but with explicit owner and two keys
+   # note that the options are set for all given keys
+   __ssh_authorized_keys some-fancy-id \
+      --owner user-name \
+      --key "ssh-rsa AXYZAAB3NzaC1yc2..." \
+      --key "ssh-rsa AZXYAAB3NzaC1yc2..." \
+      --option no-agent-forwarding \
+      --option 'from="*.example.com"' \
+      --comment 'backup server'
 
-    # authorized_keys file in non standard location
-    __ssh_authorized_keys some-fancy-id \
-       --file /etc/ssh/keys/user-name/authorized_keys \
-       --owner user-name \
-       --key "ssh-rsa AXYZAAB3NzaC1yc2..."
+   # authorized_keys file in non standard location
+   __ssh_authorized_keys some-fancy-id \
+      --file /etc/ssh/keys/user-name/authorized_keys \
+      --owner user-name \
+      --key "ssh-rsa AXYZAAB3NzaC1yc2..."
 
-    # same as above, but directory and authorized_keys file is created elswhere
-    __ssh_authorized_keys some-fancy-id \
-       --file /etc/ssh/keys/user-name/authorized_keys \
-       --owner user-name \
-       --noparent \
-       --nofile \
-       --key "ssh-rsa AXYZAAB3NzaC1yc2..."
+   # same as above, but directory and authorized_keys file is created elswhere
+   __ssh_authorized_keys some-fancy-id \
+      --file /etc/ssh/keys/user-name/authorized_keys \
+      --owner user-name \
+      --noparent \
+      --nofile \
+      --key "ssh-rsa AXYZAAB3NzaC1yc2..."
 
 
 SEE ALSO
 --------
-:strong:`sshd`\ (8)
+* :strong:`sshd`\ (8)
 
 
 AUTHORS
 -------
-Steven Armstrong <steven-cdist--@--armstrong.cc>
+* Steven Armstrong <steven-cdist--@--armstrong.cc>
 
 
 COPYING
 -------
-Copyright \(C) 2012-2014 Steven Armstrong. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2012-2014 Steven Armstrong.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__ssh_dot_ssh/man.rst
+++ b/type/__ssh_dot_ssh/man.rst
@@ -8,15 +8,22 @@ cdist-type__ssh_dot_ssh - Manage .ssh directory
 
 DESCRIPTION
 -----------
-Adds or removes .ssh directory to a user home.
+Adds or removes the ``.ssh`` directory to/from a user's home directory.
 
-This type is being used by __ssh_authorized_keys.
+This type is being used by :strong:`cdist-type__ssh_authorized_keys`\ (7).
 
 
 OPTIONAL PARAMETERS
 -------------------
 state
-   if the directory should be 'present' or 'absent', defaults to 'present'.
+   One of:
+
+   present
+      the ``.ssh`` directory exists
+   absent
+      the ``.ssh`` directory does not exist
+
+   Defaults to: ``present``
 
 
 EXAMPLES
@@ -24,26 +31,26 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Ensure root has ~/.ssh with the right permissions
-    __ssh_dot_ssh root
+   # Ensure root has ~/.ssh with the right permissions
+   __ssh_dot_ssh root
 
-    # Nico does not need ~/.ssh anymore
-    __ssh_dot_ssh nico --state absent
+   # Nico does not need ~/.ssh anymore
+   __ssh_dot_ssh nico --state absent
 
 
 SEE ALSO
 --------
-:strong:`cdist-type__ssh_authorized_keys`\ (7)
+* :strong:`cdist-type__ssh_authorized_keys`\ (7)
 
 
 AUTHORS
 -------
-Nico Schottelius <nico-cdist--@--schottelius.org>
+* Nico Schottelius <nico-cdist--@--schottelius.org>
 
 
 COPYING
 -------
-Copyright \(C) 2014 Nico Schottelius. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2014 Nico Schottelius.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__sshd_config/man.rst
+++ b/type/__sshd_config/man.rst
@@ -11,41 +11,33 @@ DESCRIPTION
 This space intentionally left blank.
 
 
-REQUIRED PARAMETERS
--------------------
-None.
-
-
 OPTIONAL PARAMETERS
 -------------------
 file
-    The path to the sshd_config file to edit.
-    Defaults to ``/etc/ssh/sshd_config``.
+   The path to the sshd_config file to edit.
+
+   Defaults to: ``/etc/ssh/sshd_config``
 match
-    Restrict this option to apply only for certain connections.
-    Allowed values are what would be allowed to be written after a ``Match``
-    keyword in ``sshd_config``, e.g. ``--match 'User anoncvs'``.
+   Restrict this option to apply only for certain connections.
+   Allowed values are what would be allowed to be written after a ``Match``
+   keyword in ``sshd_config``, e.g. ``--match 'User anoncvs'``.
 
-    Can be used multiple times. All of the values are ANDed together.
+   Can be used multiple times. All of the values are ANDed together.
 option
-    The name of the option to manipulate. Defaults to ``__object_id``.
+   The name of the option to manipulate. Defaults to ``__object_id``.
 state
-    Can be:
+   One of:
 
-    - ``present``: ensure a matching config line is present (or the default
-      value).
-    - ``absent``: ensure no matching config line is present.
+   ``present``
+      ensure a matching config line is present (or the default value).
+   ``absent``
+      ensure no matching config line is present.
 value
-    The option's value to be assigned to the option (if ``--state present``) or
-    removed (if ``--state absent``).
+   The option's value to be assigned to the option (if ``--state present``) or
+   removed (if ``--state absent``).
 
-    This option is required if ``--state present``. If not specified and
-    ``--state absent``, all values for the given option are removed.
-
-
-BOOLEAN PARAMETERS
-------------------
-None.
+   This option is required if ``--state present``. If not specified and
+   ``--state absent``, all values for the given option are removed.
 
 
 EXAMPLES
@@ -53,46 +45,46 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Disallow root logins with password
-    __sshd_config PermitRootLogin --value without-password
+   # Disallow root logins with password
+   __sshd_config PermitRootLogin --value without-password
 
-    # Disallow password-based authentication
-    __sshd_config PasswordAuthentication --value no
+   # Disallow password-based authentication
+   __sshd_config PasswordAuthentication --value no
 
-    # Accept the EDITOR environment variable
-    __sshd_config AcceptEnv:EDITOR --option AcceptEnv --value EDITOR
+   # Accept the EDITOR environment variable
+   __sshd_config AcceptEnv:EDITOR --option AcceptEnv --value EDITOR
 
-    # Force command for connections as git user
-    __sshd_config git@ForceCommand --match 'User git' --option ForceCommand \
-        --value 'cd ~git && exec git-shell ${SSH_ORIGINAL_COMMAND:+-c "${SSH_ORIGINAL_COMMAND}"}'
-
-
-SEE ALSO
---------
-:strong:`sshd_config`\ (5)
+   # Force command for connections as git user
+   __sshd_config git@ForceCommand --match 'User git' --option ForceCommand \
+       --value 'cd ~git && exec git-shell ${SSH_ORIGINAL_COMMAND:+-c "${SSH_ORIGINAL_COMMAND}"}'
 
 
 BUGS
 ----
-- This type assumes a nicely formatted config file,
+* This type assumes a nicely formatted config file,
   i.e. no config options spanning multiple lines.
-- ``Include`` directives are ignored.
-- Config options are not added/removed to/from the config file if their value is
+* ``Include`` directives are ignored.
+* Config options are not added/removed to/from the config file if their value is
   the default value.
-- | The explorer will incorrectly report ``absent`` if OpenSSH internally
+* | The explorer will incorrectly report ``absent`` if OpenSSH internally
     transforms one value to another (e.g. ``permitrootlogin prohibit-password``
     is transformed to ``permitrootlogin without-password``).
   | Workaround: Use the value that OpenSSH uses internally.
 
 
+SEE ALSO
+--------
+* :strong:`sshd_config`\ (5)
+
+
 AUTHORS
 -------
-Dennis Camera <dennis.camera--@--ssrq-sds-fds.ch>
+* Dennis Camera <dennis.camera--@--ssrq-sds-fds.ch>
 
 
 COPYING
 -------
-Copyright \(C) 2020 Dennis Camera. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2020 Dennis Camera.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__staged_file/man.rst
+++ b/type/__staged_file/man.rst
@@ -14,16 +14,11 @@ cdist) and then deployed to the target host using the __file type.
 
 REQUIRED PARAMETERS
 -------------------
-source
-   the URL from which to retrieve the source file.
+cksum
+   the output of running the command: ``cksum $source_file``
    e.g.
 
-   * https://dl.bintray.com/mitchellh/consul/0.4.1_linux_amd64.zip
-   * file:///path/to/local/file
-
-cksum
-   the output of running the command: `cksum $source-file`
-   e.g.::
+   .. code-block:: sh
 
       $ echo foobar > /tmp/foobar
       $ cksum /tmp/foobar
@@ -32,6 +27,12 @@ cksum
    If either checksum or file size has changed the file will be
    (re)fetched from the --source. The file name can be omitted and is
    ignored if given.
+source
+   the URL from which to retrieve the source file.
+   e.g.
+
+   * https://dl.bintray.com/mitchellh/consul/0.4.1_linux_amd64.zip
+   * file:///path/to/local/file
 
 
 OPTIONAL PARAMETERS
@@ -42,16 +43,12 @@ fetch-command
    parameter. The --fetch-command is expected to output the fetched file to
    stdout.
    Defaults to 'curl -s -L "%s"'.
-
 group
-   see cdist-type__file
-
-owner
-   see cdist-type__file
-
+   see :strong:`cdist-type__file`\ (7)
 mode
-   see cdist-type__file
-
+   see :strong:`cdist-type__file`\ (7)
+owner
+   see :strong:`cdist-type__file`\ (7)
 prepare-command
    the optional command used to prepare or preprocess the staged file for later
    use by the file type.
@@ -61,16 +58,17 @@ prepare-command
    It is executed in the same directory into which the fetched file has been
    saved. The --prepare-command is expected to output the final file to stdout.
 
-   So for example given a --source of https://example.com/my-zip.zip, and a
-   --prepare-command of 'unzip -p "%s"', the code `unzip -p "my-zip.zip"` will
-   be executed in the folder containing the downloaded file my-zip.zip.
-   A more complex example might be --prepare-command 'tar -xz "%s"; cat path/from/archive'
+   So for example given ``--source https://example.com/my-zip.zip``, and
+   ``--prepare-command 'unzip -p "%s"'``, the code ``unzip -p "my-zip.zip"``
+   will be executed in the folder containing the downloaded file my-zip.zip.
+   A more complex example might be
+   ``--prepare-command 'tar -xz "%s"; cat path/from/archive'``
 stage-dir
    the directory in which to store downloaded and prepared files.
-   Defaults to '/var/tmp/cdist/__staged_file'
 
+   Defaults to: ``/var/tmp/cdist/__staged_file``
 state
-   see cdist-type__file
+   see :strong:`cdist-type__file`\ (7)
 
 
 EXAMPLES
@@ -78,38 +76,38 @@ EXAMPLES
 
 .. code-block:: sh
 
-    __staged_file /usr/local/bin/consul \
-       --source file:///path/to/local/copy/consul \
-       --cksum '428915666 15738724' \
-       --state present \
-       --group root \
-       --owner root \
-       --mode 755
+   __staged_file /usr/local/bin/consul \
+      --source file:///path/to/local/copy/consul \
+      --cksum '428915666 15738724' \
+      --state present \
+      --group root \
+      --owner root \
+      --mode 755
 
-    __staged_file /usr/local/bin/consul \
-       --source https://dl.bintray.com/mitchellh/consul/0.4.1_linux_amd64.zip \
-       --cksum '428915666 15738724' \
-       --fetch-command 'curl -s -L "%s"' \
-       --prepare-command 'unzip -p "%s"' \
-       --state present \
-       --group root \
-       --owner root \
-       --mode 755
+   __staged_file /usr/local/bin/consul \
+      --source https://dl.bintray.com/mitchellh/consul/0.4.1_linux_amd64.zip \
+      --cksum '428915666 15738724' \
+      --fetch-command 'curl -s -L "%s"' \
+      --prepare-command 'unzip -p "%s"' \
+      --state present \
+      --group root \
+      --owner root \
+      --mode 755
 
 
 SEE ALSO
 --------
-:strong:`cdist-type__file`\ (7)
+* :strong:`cdist-type__file`\ (7)
 
 
 AUTHORS
 -------
-Steven Armstrong <steven-cdist--@--armstrong.cc>
+* Steven Armstrong <steven-cdist--@--armstrong.cc>
 
 
 COPYING
 -------
-Copyright \(C) 2015 Steven Armstrong. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2015 Steven Armstrong.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__start_on_boot/man.rst
+++ b/type/__start_on_boot/man.rst
@@ -15,17 +15,21 @@ Warning: This type has not been tested intensively and is not fully
 supported.
 
 
-REQUIRED PARAMETERS
--------------------
-None.
-
-
 OPTIONAL PARAMETERS
 -------------------
 state
-    Either "present" or "absent", defaults to "present"
+   One of:
+
+   present
+      the service is auto-started on boot
+   absent
+      the service is not auto-started on boot
+
+   Defaults to: ``present``
 target_runlevel
-    Runlevel which should be modified, defaults to "default" (only used on gentoo systems).
+   Runlevel which should be modified (only used on Gentoo systems).
+
+   Defaults to: ``default``
 
 
 EXAMPLES
@@ -33,29 +37,29 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Ensure snmpd is started at boot
-    __start_on_boot snmpd
+   # Ensure snmpd is started at boot
+   __start_on_boot snmpd
 
-    # Same, but more explicit
-    __start_on_boot snmpd --state present
+   # Same, but more explicit
+   __start_on_boot snmpd --state present
 
-    # Ensure legacy configuration management will not be started
-    __start_on_boot puppet --state absent
+   # Ensure legacy configuration management will not be started
+   __start_on_boot puppet --state absent
 
 
 SEE ALSO
 --------
-:strong:`cdist-type__process`\ (7)
+* :strong:`cdist-type__process`\ (7)
 
 
 AUTHORS
 -------
-Nico Schottelius <nico-cdist--@--schottelius.org>
+* Nico Schottelius <nico-cdist--@--schottelius.org>
 
 
 COPYING
 -------
-Copyright \(C) 2012-2019 Nico Schottelius. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2012-2019 Nico Schottelius.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__svn/man.rst
+++ b/type/__svn/man.rst
@@ -14,12 +14,27 @@ This cdist type allows you to check out Subversion (SVN) repositories.
 REQUIRED PARAMETERS
 -------------------
 source
-    the SVN repository to check out.
-    The value may be a subdirectory of the repository to check out.
+   the SVN repository to check out.
+   The value may be a subdirectory of the repository to check out.
 
 
 OPTIONAL PARAMETERS
 -------------------
+group
+   Group to :strong:`chgrp`\ (1) all the files in the working copy to.
+mode
+   Unix mode to set for all the files in the working copy.
+
+   Format: suitable for :strong:`chmod`\ (1)
+owner
+   User to :strong:`chown`\ (1) all the files in the working copy to.
+password
+   Password of ``--username``.
+
+   *Security note:* if possible it should be avoided to use the ``--username``
+   and ``--password`` parameters because the password will be copied to the
+   target host in plain text.
+   If possible it is advisable to use SSH "deploy keys" instead.
 state
    One of
 
@@ -29,23 +44,8 @@ state
       No directory exists at ``__object_id``.
 
    Defaults to: ``present``
-owner
-   User to :strong:`chown`\ (1) all the files in the working copy to.
-group
-   Group to :strong:`chgrp`\ (1) all the files in the working copy to.
-mode
-   Unix mode to set for all the files in the working copy.
-
-   Format: suitable for :strong:`chmod`\ (1)
 username
    Username to use to authenticate to SVN server.
-password
-   Password of ``--username``.
-
-   *Security note:* if possible it should be avoided to use the ``--username``
-   and ``--password`` parameters because the password will be copied to the
-   target host in plain text.
-   If possible it is advisable to use SSH "deploy keys" instead.
 
 
 EXAMPLES
@@ -59,12 +59,12 @@ EXAMPLES
 
 SEE ALSO
 --------
-:strong:`cdist-type__git`\ (7)
+* :strong:`cdist-type__git`\ (7)
 
 
 AUTHORS
 -------
-Dennis Camera <dennis.camera--@--ssrq-sds-fds.ch>
+* Dennis Camera <dennis.camera--@--ssrq-sds-fds.ch>
 
 
 COPYING

--- a/type/__sysctl/man.rst
+++ b/type/__sysctl/man.rst
@@ -9,14 +9,14 @@ cdist-type__sysctl - manage sysctl settings
 DESCRIPTION
 -----------
 Manages permanent as well as runtime sysctl settings.
-Permament settings are set by managing entries in /etc/sysctl.conf.
+Permament settings are set by managing entries in ``/etc/sysctl.conf``.
 Runtime settings are set by directly calling the sysctl executable.
 
 
 REQUIRED PARAMETERS
 -------------------
 value
-   The value to set for the given key (object_id)
+   The value to set for the given key (``__object_id``)
 
 
 EXAMPLES
@@ -24,23 +24,24 @@ EXAMPLES
 
 .. code-block:: sh
 
-    __sysctl net.ipv4.ip_forward --value 1
+   __sysctl net.ipv4.ip_forward --value 1
 
-    # On some operating systems, e.g. NetBSD, to prevent an error if the
-    # MIB style name does not exist (e.g. optional kernel components),
-    # name and value can be separated by `?=`. The same effect can be achieved
-    # in cdist by appending a `?` to the key:
+   # On some operating systems, e.g. NetBSD, to prevent an error if the
+   # MIB style name does not exist (e.g. optional kernel components),
+   # name and value can be separated by `?=`. The same effect can be achieved
+   # in cdist by appending a `?` to the key:
 
-    __sysctl ddb.onpanic? --value -1
+   __sysctl ddb.onpanic? --value -1
 
 
 AUTHORS
 -------
-Steven Armstrong <steven-cdist--@--armstrong.cc>
+* Steven Armstrong <steven-cdist--@--armstrong.cc>
 
 
 COPYING
 -------
-Copyright \(C) 2014 Steven Armstrong. Free use of this software is
-granted under the terms of the GNU General Public License version 3 or
-later (GPLv3+).
+Copyright \(C) 2014 Steven Armstrong.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__systemd_service/man.rst
+++ b/type/__systemd_service/man.rst
@@ -16,60 +16,74 @@ The activation or deactivation is out of scope. Look for the
 :strong:`cdist-type__systemd_util`\ (7) type instead.
 
 
-REQUIRED PARAMETERS
--------------------
-None.
-
-
 OPTIONAL PARAMETERS
 -------------------
-
-name
-    String which will used as name instead of the object id.
-
-state
-    The state which the service should be in:
-
-    running
-        Service should run (default)
-
-    stopped
-        Service should be stopped
-
 action
-    Executes an action on on the service. It will only execute it if the
-    service keeps the state ``running``. There are following actions, where:
+   Executes an action on on the service. It will only execute it if the
+   service keeps the state ``running``. There are following actions, where:
 
-    reload
-        Reloads the service
+   reload
+      Reloads the service
 
-    restart
-        Restarts the service
+   restart
+      Restarts the service
+name
+   String which will used as name instead of the object id.
+state
+   The state which the service should be in:
+
+   running
+      Service should run (default)
+
+   stopped
+      Service should be stopped
+
 
 BOOLEAN PARAMETERS
 ------------------
-
 if-required
-    Only execute the action if at minimum one required type outputs a message
-    to ``$__messages_out``. Through this, the action should only executed if a
-    dependency did something. The action will not executed if no dependencies
-    given.
+   Only execute the action if at minimum one required type outputs a message
+   to ``$__messages_out``. Through this, the action should only executed if a
+   dependency did something. The action will not executed if no dependencies
+   given.
 
 
 MESSAGES
 --------
-
 start
-    Started the service
-
+   Started the service
 stop
-    Stopped the service
-
+   Stopped the service
 restart
-    Restarted the service
-
+   Restarted the service
 reload
-    Reloaded the service
+   Reloaded the service
+
+
+EXAMPLES
+--------
+
+.. code-block:: sh
+
+   # service must run
+   __systemd_service nginx
+
+   # service must stopped
+   __systemd_service sshd \
+       --state stopped
+
+   # restart the service
+   __systemd_service apache2 \
+       --action restart
+
+   # makes sure the service exist with an alternative name
+   __systemd_service foo \
+       --name sshd
+
+   # reload the service for a modified configuration file
+   # only reloads the service if the file really changed
+   require="__file/etc/foo.conf" __systemd_service foo \
+       --action reload --if-required
 
 
 ABORTS
@@ -79,39 +93,14 @@ Aborts in following cases:
 systemd or the service does not exist
 
 
-EXAMPLES
---------
-.. code-block:: sh
-
-    # service must run
-    __systemd_service nginx
-
-    # service must stopped
-    __systemd_service sshd \
-        --state stopped
-
-    # restart the service
-    __systemd_service apache2 \
-        --action restart
-
-    # makes sure the service exist with an alternative name
-    __systemd_service foo \
-        --name sshd
-
-    # reload the service for a modified configuration file
-    # only reloads the service if the file really changed
-    require="__file/etc/foo.conf" __systemd_service foo \
-        --action reload --if-required
-
-
 AUTHORS
 -------
-Matthias Stecher <matthiasstecher at gmx.de>
+* Matthias Stecher <matthiasstecher at gmx.de>
 
 
 COPYING
 -------
-Copyright \(C) 2020 Matthias Stecher. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2020 Matthias Stecher.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__systemd_unit/man.rst
+++ b/type/__systemd_unit/man.rst
@@ -3,90 +3,76 @@ cdist-type__systemd_unit(7)
 
 NAME
 ----
-
 cdist-type__systemd_unit - Install a systemd unit
+
 
 DESCRIPTION
 -----------
-
 This type manages systemd units in ``/etc/systemd/system/``. It can install,
 enable and start a systemd unit. This is particularly useful on systems which
 take advantage of systemd heavily (e.g., CoreOS). For more information about
 systemd units, see SYSTEMD.UNIT(5).
 
-REQUIRED PARAMETERS
--------------------
-
-None.
 
 OPTIONAL PARAMETERS
 -------------------
-
-enablement-state
-    'enabled', 'disabled' or 'masked', where:
-
-    enabled
-        enables the unit
-    disabled
-        disables the unit
-    masked
-        masks the unit
-
-source
-    Path to the config file. If source is '-' (dash), take what was written to
-    stdin as the config file content.
-
-state
-    'present' or 'absent', defaults to 'present' where:
-
-    present
-        the unit (or its mask) is installed
-    absent
-        The unit is stopped, disabled and uninstalled. If the unit was masked,
-        the mask is removed.
-
 drop-in
-    Create drop-in file for existing unit.
+   Create drop-in file for existing unit.
+enablement-state
+   'enabled', 'disabled' or 'masked', where:
+
+   enabled
+      enables the unit
+   disabled
+      disables the unit
+   masked
+      masks the unit
+source
+   Path to the config file. If source is '-' (dash), take what was written to
+   stdin as the config file content.
+state
+   'present' or 'absent', defaults to 'present' where:
+
+   present
+      the unit (or its mask) is installed
+   absent
+      The unit is stopped, disabled and uninstalled. If the unit was masked,
+      the mask is removed.
+
 
 BOOLEAN PARAMETERS
 ------------------
-
 restart
-    Start the unit if it was inactive. Restart the unit if the unit file
-    changed. Stop the unit if new ``enablement-state`` is ``masked``.
+   Start the unit if it was inactive. Restart the unit if the unit file
+   changed. Stop the unit if new ``enablement-state`` is ``masked``.
 
-MESSAGES
---------
-
-None.
 
 EXAMPLES
 --------
 
 .. code-block:: sh
 
-    # Installs, enables and starts foobar.service
-    __systemd_unit foobar.service \
-        --source "${__manifest}/files/foobar.service" \
-        --enablement-state enabled \
-        --restart
+   # Installs, enables and starts foobar.service
+   __systemd_unit foobar.service \
+       --source "${__manifest}/files/foobar.service" \
+       --enablement-state enabled \
+       --restart
 
-    # Disables the unit
-    __systemd_unit foobar.service --enablement-state disabled
+   # Disables the unit
+   __systemd_unit foobar.service --enablement-state disabled
 
-    # Stops, disables and uninstalls foobar.service
-    __systemd_unit foobar.service --state absent
+   # Stops, disables and uninstalls foobar.service
+   __systemd_unit foobar.service --state absent
 
 
 AUTHORS
 -------
+* Ľubomír Kučera <lubomir.kucera.jr at gmail.com>
 
-Ľubomír Kučera <lubomir.kucera.jr at gmail.com>
 
 COPYING
 -------
-
-Copyright \(C) 2017 Ľubomír Kučera. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2017 Ľubomír Kučera.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__timezone/man.rst
+++ b/type/__timezone/man.rst
@@ -15,12 +15,7 @@ This type creates a symlink (/etc/localtime) to the selected timezone
 REQUIRED PARAMETERS
 -------------------
 tz
-    The name of timezone to set.
-
-
-OPTIONAL PARAMETERS
--------------------
-None.
+   The name of the timezone to set.
 
 
 EXAMPLES
@@ -28,24 +23,24 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Set up Europe/Andorra as our timezone.
-    __timezone --tz Europe/Andorra
+   # Set up Europe/Andorra as our timezone.
+   __timezone --tz Europe/Andorra
 
-    # Set up US/Central as our timezone.
-    __timezone --tz US/Central
+   # Set up US/Central as our timezone.
+   __timezone --tz US/Central
 
 
 AUTHORS
 -------
-| Steven Armstrong <steven-cdist--@--armstrong.cc>
-| Nico Schottelius <nico-cdist--@--schottelius.org>
-| Ramon Salvadó <rsalvado--@--gnuine--dot--com>
-| Dennis Camera <dennis.camera--@--ssrq-sds-fds.ch>
+* Steven Armstrong <steven-cdist--@--armstrong.cc>
+* Nico Schottelius <nico-cdist--@--schottelius.org>
+* Ramon Salvadó <rsalvado--@--gnuine--dot--com>
+* Dennis Camera <dennis.camera--@--ssrq-sds-fds.ch>
 
 
 COPYING
 -------
-Copyright \(C) 2012-2020 the `AUTHORS`_. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2012-2020 the `AUTHORS`_.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__uci/man.rst
+++ b/type/__uci/man.rst
@@ -36,11 +36,6 @@ type
    Defaults to auto-detect based on the number of ``--value`` parameters.
 
 
-BOOLEAN PARAMETERS
-------------------
-None.
-
-
 EXAMPLES
 --------
 
@@ -64,12 +59,12 @@ EXAMPLES
 
 SEE ALSO
 --------
-- https://openwrt.org/docs/guide-user/base-system/uci
+* https://openwrt.org/docs/guide-user/base-system/uci
 
 
 AUTHORS
 -------
-Dennis Camera <cdist--@--dtnr.ch>
+* Dennis Camera <cdist--@--dtnr.ch>
 
 
 COPYING

--- a/type/__uci_section/man.rst
+++ b/type/__uci_section/man.rst
@@ -22,11 +22,6 @@ matching section by one of its options using the ``--match`` parameter.
 or ``--list`` will be deleted.
 
 
-REQUIRED PARAMETERS
--------------------
-None.
-
-
 OPTIONAL PARAMETERS
 -------------------
 list
@@ -56,11 +51,6 @@ state
    ``present`` or ``absent``, defaults to ``present``.
 type
    The type of the section in the format: ``<config>.<section-type>``
-
-
-BOOLEAN PARAMETERS
-------------------
-None.
 
 
 EXAMPLES
@@ -103,13 +93,13 @@ EXAMPLES
 
 SEE ALSO
 --------
-- https://openwrt.org/docs/guide-user/base-system/uci
-- :strong:`cdist-type__uci`\ (7)
+* https://openwrt.org/docs/guide-user/base-system/uci
+* :strong:`cdist-type__uci`\ (7)
 
 
 AUTHORS
 -------
-Dennis Camera <cdist--@--dtnr.ch>
+* Dennis Camera <cdist--@--dtnr.ch>
 
 
 COPYING

--- a/type/__unpack/man.rst
+++ b/type/__unpack/man.rst
@@ -26,32 +26,28 @@ destination
 OPTIONAL PARAMETERS
 -------------------
 sum-file
-    Override archive's checksum file in target. By default
-    ``XXX.cdist__unpack_sum`` will be used, where ``XXX`` is source
-    archive path. This file must be kept in target's persistent storage.
-
-tar-strip
-    Tarball specific. See ``man tar`` for ``--strip-components``.
-
+   Override archive's checksum file in target. By default
+   ``XXX.cdist__unpack_sum`` will be used, where ``XXX`` is source
+   archive path. This file must be kept in target's persistent storage.
 tar-extra-args
-    Tarball sepcific. Append additional arguments to ``tar`` command.
-    See ``man tar`` for possible arguments.
+   Tarball sepcific. Append additional arguments to ``tar`` command.
+   See :strong:`tar`\ (1) for possible arguments.
+tar-strip
+   Tarball specific. See :strong:`tar`\ (1) for ``--strip-components``.
 
 
 BOOLEAN PARAMETERS
 ------------------
 backup-destination
-    By default destination file will be overwritten. In case destination
-    is directory, files from archive will be added to or overwritten in
-    directory. This parameter moves existing destination to
-    ``XXX.cdist__unpack_backup_YYY``, where ``XXX`` is destination and
-    ``YYY`` current UNIX timestamp.
-
-preserve-archive
-    Don't delete archive after unpacking.
-
+   By default destination file will be overwritten. In case destination
+   is directory, files from archive will be added to or overwritten in
+   directory. This parameter moves existing destination to
+   ``XXX.cdist__unpack_backup_YYY``, where ``XXX`` is destination and
+   ``YYY`` current UNIX timestamp.
 onchange
-    Execute this command after unpack.
+   Execute this command after unpack.
+preserve-archive
+   Don't delete archive after unpacking.
 
 
 EXAMPLES
@@ -59,35 +55,35 @@ EXAMPLES
 
 .. code-block:: sh
 
-    __directory /opt/cpma
+   __directory /opt/cpma
 
-    require='__directory/opt/cpma' \
-        __download /opt/cpma/cnq3.zip \
-            --url https://cdn.playmorepromode.com/files/cnq3/cnq3-1.51.zip \
-            --sum md5:46da3021ca9eace277115ec9106c5b46
+   require='__directory/opt/cpma' \
+       __download /opt/cpma/cnq3.zip \
+           --url https://cdn.playmorepromode.com/files/cnq3/cnq3-1.51.zip \
+           --sum md5:46da3021ca9eace277115ec9106c5b46
 
-    require='__download/opt/cpma/cnq3.zip' \
-        __unpack /opt/cpma/cnq3.zip \
-            --backup-destination \
-            --preserve-archive \
-            --destination /opt/cpma/server
+   require='__download/opt/cpma/cnq3.zip' \
+       __unpack /opt/cpma/cnq3.zip \
+           --backup-destination \
+           --preserve-archive \
+           --destination /opt/cpma/server
 
-    # example usecase for --tar-* args
-    __unpack /root/strelaysrv.tar.gz \
-        --preserve-archive \
-        --destination /usr/local/bin \
-        --tar-strip 1 \
-        --tar-extra-args '--wildcards "*/strelaysrv"'
+   # example usecase for --tar-* args
+   __unpack /root/strelaysrv.tar.gz \
+       --preserve-archive \
+       --destination /usr/local/bin \
+       --tar-strip 1 \
+       --tar-extra-args '--wildcards "*/strelaysrv"'
 
 
 AUTHORS
 -------
-Ander Punnar <ander-at-kvlt-dot-ee>
+* Ander Punnar <ander-at-kvlt-dot-ee>
 
 
 COPYING
 -------
-Copyright \(C) 2020 Ander Punnar. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2020 Ander Punnar.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__update_alternatives/man.rst
+++ b/type/__update_alternatives/man.rst
@@ -30,24 +30,25 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Setup vim as the default editor
-    __update_alternatives editor --path /usr/bin/vim.basic
+   # Setup vim as the default editor
+   __update_alternatives editor --path /usr/bin/vim.basic
 
 
 SEE ALSO
 --------
-:strong:`cdist-type__debconf_set_selections`\ (7), :strong:`update-alternatives`\ (8)
+* :strong:`cdist-type__debconf_set_selections`\ (7)
+* :strong:`update-alternatives`\ (8)
 
 
 AUTHORS
 -------
-Nico Schottelius <nico-cdist--@--schottelius.org>
-Ander Punnar <ander@kvlt.ee>
+* Nico Schottelius <nico-cdist--@--schottelius.org>
+* Ander Punnar <ander@kvlt.ee>
 
 
 COPYING
 -------
-Copyright \(C) 2013 Nico Schottelius and 2020 Ander Punnar. You can
-redistribute it and/or modify it under the terms of the GNU General Public
-License as published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2013 Nico Schottelius and 2020 Ander Punnar.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__user/man.rst
+++ b/type/__user/man.rst
@@ -11,95 +11,83 @@ DESCRIPTION
 This cdist type allows you to create or modify users on the target.
 
 
-REQUIRED PARAMETERS
--------------------
-None.
-
-
 OPTIONAL PARAMETERS
 -------------------
-state
-    absent or present, defaults to present
-
 comment
-    see usermod(8)
-
-home
-    see above
-
+   see :strong:`usermod`\ (8)
 gid
-    see above
-
+   see :strong:`usermod`\ (8)
+home
+   see :strong:`usermod`\ (8)
 password
-    see above
-
+   see :strong:`usermod`\ (8)
 shell
-    see above
+   see :strong:`usermod`\ (8)
+state
+   ``present`` or ``absent``
 
+   Defaults to: ``present``
 uid
-    see above
+   see :strong:`usermod`\ (8)
 
 
 BOOLEAN PARAMETERS
 ------------------
-system
-    see useradd(8), apply only on user create
-
 create-home
-    see useradd(8), apply only on user create
-
+   see :strong:`useradd`\ (8), applied only on user creation
 remove-home
-    see userdel(8), apply only on user delete
+   see :strong:`userdel`\ (8), applied only on user deletion
+system
+   see :strong:`useradd`\ (8), applied only on user creation
 
 
 MESSAGES
 --------
 mod
-    User is modified
-
+   User is modified
 add
-    New user added
-
+   New user added
 userdel -r
-    If user was deleted with homedir
-
+   If user was deleted with homedir
 userdel
-    If user was deleted (keeping homedir)
+   If user was deleted (keeping homedir)
+
 
 EXAMPLES
 --------
 
 .. code-block:: sh
 
-    # Create user account for foobar with operating system default settings
-    __user foobar
+   # Create user account for foobar with operating system default settings
+   __user foobar
 
-    # Same but with a different shell
-    __user foobar --shell /bin/zsh
+   # Same but with a different shell
+   __user foobar --shell /bin/zsh
 
-    # Same but for a system account
-    __user foobar --system
+   # Same but for a system account
+   __user foobar --system
 
-    # Set explicit uid and home
-    __user foobar --uid 1001 --shell /bin/zsh --home /home/foobar
+   # Set explicit uid and home
+   __user foobar --uid 1001 --shell /bin/zsh --home /home/foobar
 
-    # Drop user if exists
-    __user foobar --state absent
+   # Drop user if exists
+   __user foobar --state absent
 
 
 SEE ALSO
 --------
-:strong:`pw`\ (8), :strong:`usermod`\ (8)
+* :strong:`pw`\ (8) (FreeBSD)
+* :strong:`usermod`\ (8)
 
 
 AUTHORS
 -------
-Steven Armstrong <steven-cdist--@--armstrong.cc>
+* Steven Armstrong <steven-cdist--@--armstrong.cc>
 
 
 COPYING
 -------
-Copyright \(C) 2011 Steven Armstrong. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2011 Steven Armstrong.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__user_groups/man.rst
+++ b/type/__user_groups/man.rst
@@ -20,11 +20,12 @@ group
 
 OPTIONAL PARAMETERS
 -------------------
-user
-   the name of the user. Defaults to object_id
-
 state
    absent or present. Defaults to present.
+user
+   the name of the user.
+
+   Defaults to: ``__object_id``
 
 
 EXAMPLES
@@ -32,21 +33,21 @@ EXAMPLES
 
 .. code-block:: sh
 
-    __user_groups nginx --group webuser1 --group webuser2
+   __user_groups nginx --group webuser1 --group webuser2
 
-    # remove user nginx from groups webuser2
-    __user_groups nginx-webuser2 --user nginx \
-       --group webuser2 --state absent
+   # remove user nginx from groups webuser2
+   __user_groups nginx-webuser2 --user nginx \
+      --group webuser2 --state absent
 
 
 AUTHORS
 -------
-Steven Armstrong <steven-cdist--@--armstrong.cc>
+* Steven Armstrong <steven-cdist--@--armstrong.cc>
 
 
 COPYING
 -------
-Copyright \(C) 2012 Steven Armstrong. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2012 Steven Armstrong.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__zypper_repo/man.rst
+++ b/type/__zypper_repo/man.rst
@@ -11,29 +11,34 @@ DESCRIPTION
 zypper is usually used on the SuSE distribution to manage repositories.
 
 
-REQUIRED PARAMETERS
--------------------
-None
-
-
 OPTIONAL PARAMETERS
 -------------------
-state
-    Either "present" or "absent" or "enabled" or "disabled", defaults to "present"
-
-    * **present**  - make sure that the repo is available, needs uri and repo_desc for all following states, the repo can be searched via repo_id or uri
-    * **absent**   - drop the repo if found + 
-    * **enabled**  - a repo can have state disabled if installed via zypper service (ris), in this case, you can enable the repo
-    * **disabled** - instead of absent (drop), a repo can also set to disabled, which makes it inaccessible
-
-uri
-    If supplied, use the uri and not the object id as repo uri.
-
 repo_desc
-    If supplied, use the description and not the object id as repo description, only used if the state is present and the repo has to be created
-
+   If supplied, use the description and not the object id as repo description,
+   only used if ``--state present`` and the repo has to be created
 repo_id
-    If supplied, use the id and not the object id as repo id, can be used with state absent, enabled and disabled
+   the repo id to use.
+   Can be used with state absent, enabled and disabled.
+
+   Defaults to: ``__object_id``
+state
+   One of:
+
+   present
+      make sure that the repo is available, needs uri and repo_desc for all
+      following states, the repo can be searched via repo_id or uri
+   absent
+      drop the repo if found
+   enabled
+      a repo can have state disabled if installed via zypper service (ris), in
+      this case, you can enable the repo
+   disabled
+      instead of absent (drop), a repo can also set to disabled, which makes it
+       inaccessible
+
+   Defaults to: ``present``
+uri
+   If supplied, use the uri and not the object id as repo uri.
 
 
 EXAMPLES
@@ -41,33 +46,40 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Ensure testrepo in installed
-    __zypper_repo testrepo --state present --uri http://url.to.your.repo/with/path
+   # Ensure testrepo in installed
+   __zypper_repo testrepo \
+      --state present \
+      --uri http://url.to.your.repo/with/path
 
-    # Drop repo by repo uri
-    __zypper_repo testrepo --state absent --uri http://url.to.your.repo/with/path
+   # Drop repo by repo uri
+   __zypper_repo testrepo \
+      --state absent --uri http://url.to.your.repo/with/path
 
-    # Drop repo by id number (attention: repos are always numbered from 1 to max)
-    __zypper_repo testrepo --state absent --repo_id 1
+   # Drop repo by id number (attention: repos are always numbered from 1 to max)
+   __zypper_repo testrepo \
+      --state absent --repo_id 1
 
-    # enable repo by id
-    __zypper_repo testrepo2 --state enabled --repo_id 2
+   # enable repo by id
+   __zypper_repo testrepo2 \
+      --state enabled --repo_id 2
 
-    # enable repo by uri
-    __zypper_repo testrepo3 --state enabled --uri http://url.to.your.repo/with/path
+   # enable repo by uri
+   __zypper_repo testrepo3 \
+      --state enabled --uri http://url.to.your.repo/with/path
 
-    # disable a repo works like enabling it
-    __zypper_repo testrepo4 --state disabled --repo_id 4
+   # disable a repo works like enabling it
+   __zypper_repo testrepo4 \
+      --state disabled --repo_id 4
 
 
 AUTHORS
 -------
-Daniel Heule <hda--@--sfs.biz>
+* Daniel Heule <hda--@--sfs.biz>
 
 
 COPYING
 -------
-Copyright \(C) 2013 Daniel Heule. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2013 Daniel Heule.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.

--- a/type/__zypper_service/man.rst
+++ b/type/__zypper_service/man.rst
@@ -14,26 +14,27 @@ zypper is usually used on SuSE systems to manage services.
 REQUIRED PARAMETERS
 -------------------
 uri
-    Uri of the service
+   Uri of the service
 
 
 OPTIONAL PARAMETERS
 -------------------
 service_desc
-    If supplied, use the service_desc and not the object id as description for the service.
-
+   If supplied, use the service_desc and not the object id as description for
+   the service.
 state
-    Either "present" or "absent", defaults to "present"
+   Either ``present`` or ``absent``.
 
+   Defaults to: ``present``
 type
-    Defaults to "ris", the standard type of services at SLES11. For other values, see manpage of zypper.
+   Defaults to "ris", the standard type of services at SLES11.
+   For other values, see :strong:`zypper`\ (8).
 
 
 BOOLEAN PARAMETERS
 ------------------
 remove-all-other-services
    Drop all other services found on the target host before adding the new one.
-
 remove-all-repos
    If supplied, remove all existing repos prior to setup the new service.
 
@@ -43,24 +44,34 @@ EXAMPLES
 
 .. code-block:: sh
 
-    # Ensure that internal SLES11 SP3 RIS is in installed and all other services and repos are discarded
-    __zypper_service INTERNAL_SLES11_SP3 --service_desc "Internal SLES11 SP3 RIS" --uri "http://path/to/your/ris/dir" --remove-all-other-services --remove-all-repos
+   # Ensure that internal SLES11 SP3 RIS is in installed and all other services
+   # and repos are discarded
+   __zypper_service INTERNAL_SLES11_SP3 \
+      --service_desc 'Internal SLES11 SP3 RIS' \
+      --uri 'http://path/to/your/ris/dir' \
+      --remove-all-other-services \
+      --remove-all-repos
 
-    # Ensure that internal SLES11 SP3 RIS is in installed, no changes to other services or repos
-    __zypper_service INTERNAL_SLES11_SP3 --service_desc "Internal SLES11 SP3 RIS" --uri "http://path/to/your/ris/dir"
+   # Ensure that internal SLES11 SP3 RIS is in installed, no changes to other
+   # services or repos
+   __zypper_service INTERNAL_SLES11_SP3 \
+      --service_desc 'Internal SLES11 SP3 RIS' \
+      --uri 'http://path/to/your/ris/dir'
 
-    # Drop service by uri, no changes to other services or repos
-    __zypper_service INTERNAL_SLES11_SP3 --state absent --uri "http://path/to/your/ris/dir"
+   # Drop service by uri, no changes to other services or repos
+   __zypper_service INTERNAL_SLES11_SP3 \
+      --state absent \
+      --uri 'http://path/to/your/ris/dir'
 
 
 AUTHORS
 -------
-Daniel Heule <hda--@--sfs.biz>
+* Daniel Heule <hda--@--sfs.biz>
 
 
 COPYING
 -------
-Copyright \(C) 2013 Daniel Heule. You can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+Copyright \(C) 2013 Daniel Heule.
+You can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.


### PR DESCRIPTION
In this PR the `man.rst` files of the base types were auto reformatted by sending them through [skonfig-man-lint.py](https://gist.github.com/sideeffect42/b1865f5fe4b1e6b907cb4b50191cc3f0). The script parses the `man.rst` files using [docutils](https://www.docutils.org/) and then re-serialises them using common rules for all man pages.

The command used was:
```
$ find type -type f -name man.rst -exec sh -c './skonfig-man-lint.py "$1" >"$1.tmp" && mv "$1.tmp" "$1"' -- {} \;
```

Some manual checking and corrections were then applied to the result of the script.

Changes made in general:
* removed empty sections,
* parameters are always lexicographically sorted within their section,
* `SEE ALSO` and `AUTHORS` are always lists,
* sections are always in the same order:
  1. `NAME`
  2. `DESCRIPTION`
  3. `REQUIRED MULTIPLE PARAMETERS`
  4. `REQUIRED PARAMETERS`
  5. `OPTIONAL MULTIPLE PARAMETERS`
  6. `OPTIONAL PARAMETERS`
  7. `BOOLEAN PARAMETERS`
  8. (other `PARAMETERS` sections if used)
  9. `MESSAGES`
  10. `EXAMPLES`
  11. (custom sections, see below)
  12. `SEE ALSO`
  13. `AUTHORS`
  14. `COPYING`
* lists always use `*`,
* always two empty lines before a new section, no empty lines after the section title, and no empty lines between parameter descriptions,
* blocks are always indented using three spaces,
* lines are no longer than 80 characters,
* the GPL copyright notice starts starts on a new line and the same language is used for all types.

Custom sections: all section names other than the ones listed above are considered custom sections by `skonfig-man-lint.py`.
The following types have such custom sections:
* type/__sensible_editor/man.rst: LIMITATIONS
* type/__sshd_config/man.rst: BUGS
* type/__key_value/man.rst: MORE INFORMATION
* type/__systemd_service/man.rst: ABORTS
* type/__dpkg_architecture/man.rst: ABORTS
* type/__package_pkgng_freebsd/man.rst: CAVEATS
