### PR TITLE
__skonfigmarker: New type

### DIFF
--- a/type/__cdistmarker/deprecated
+++ b/type/__cdistmarker/deprecated
@@ -1,0 +1,1 @@
+We're all using skonfig now, aren't we? __skonfigmarker is a drop-in replacement for __cdistmarker.

--- a/type/__skonfigmarker/gencode-remote
+++ b/type/__skonfigmarker/gencode-remote
@@ -1,0 +1,43 @@
+#!/bin/sh -e
+#
+# 2023 Dennis Camera (dennis.camera at riiengineering.ch)
+#
+# This file is part of skonfig.
+#
+# skonfig is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig. If not, see <http://www.gnu.org/licenses/>.
+#
+
+shquot() {
+	sed -e "s/'/'\\\\''/g" -e "1s/^/'/" -e "\$s/\$/'/" <<-EOF
+	$*
+	EOF
+}
+
+destination=$(cat "${__object:?}/parameter/destination")
+if test -s "${__object:?}/parameter/format"
+then
+	format=$(cat "${__object:?}/parameter/format")
+fi
+
+printf 'date -u %s>%s\n' \
+	"${format:++$(shquot "${format}") }" \
+	"$(shquot "${destination}")"
+
+if cmp -s "${__type:?}/parameter/default/destination" "${__object:?}/parameter/destination"
+then
+	# if the user doesn't override --destination, also create a
+	# cdist-configured file for compatibility with cdist-type__cdistmarker(7)
+	printf 'cat %s >/etc/cdist-configured\n' \
+		"$(shquot "${destination}")"
+fi

--- a/type/__skonfigmarker/man.rst
+++ b/type/__skonfigmarker/man.rst
@@ -1,0 +1,66 @@
+cdist-type__skonfigmarker(7)
+============================
+
+NAME
+----
+cdist-type__skonfigmarker - Set the "skonfigured" marker.
+
+
+DESCRIPTION
+-----------
+This type creates or updates a marker file every time it is run. The destination
+of the marker file can be specified using the ``--destination`` parameter.
+The marker file contains a timestamp which can be used to determine the last
+time :strong:`skonfig`\ (1) was run on this target.
+
+
+OPTIONAL PARAMETERS
+-------------------
+destination
+   The pathname of the marker to be created.
+
+   Defaults to: ``/etc/skonfigured``
+format
+   The format of the timestamp which will be stored in ``--destination``.
+   The value can be any format specifier supported by :strong:`date`\ (1)
+   without the leading ``+``.
+
+   The timestamp uses the UTC timezone.
+
+   The default is the output of ``date``.
+
+
+EXAMPLES
+--------
+
+.. code-block:: sh
+
+   # Create a default marker
+   __skonfigmarker
+
+   # Create a marker file containing the date in ISO 8601 format.
+   __skonfigmarker --format '%Y-%m-%dT%H:%M:%SZ'
+
+   # Create a marker file in a different location and containing the timestamp
+   # in UNIX epoch format
+   __skonfigmarker --destination /tmp/mymarker --format '%s'
+
+
+SEE ALSO
+--------
+* :strong:`cdist-type__cdistmarker`\ (7)
+
+
+AUTHORS
+-------
+* Dennis Camera <dennis.camera--@--riiengineering.ch>
+
+
+COPYING
+-------
+| Copyright \(C) 2023 Dennis Camera.
+| This type is inspired by the original :strong:`cdist-type__cdistmarker`\ (7):
+  Copyright \(C) 2011 Daniel Maher <phrawzty+cdist--@--gmail.com>.
+| You can redistribute it and/or modify it under the terms of the GNU General
+  Public License as published by the Free Software Foundation, either version 3
+  of the License, or (at your option) any later version.

--- a/type/__skonfigmarker/parameter/default/destination
+++ b/type/__skonfigmarker/parameter/default/destination
@@ -1,0 +1,1 @@
+/etc/skonfigured

--- a/type/__skonfigmarker/parameter/optional
+++ b/type/__skonfigmarker/parameter/optional
@@ -1,0 +1,2 @@
+destination
+format


### PR DESCRIPTION
We're using skonfig now, aren't we? Yet, we still use the `cdist-configured` marker file.

I propose to replace `__cdistmarker` with `__skonfigmarker` which creates a `/etc/skonfigured` marker file, instead.

Currently, the `__skonfigmarker` in this PR still creates `/etc/cdist-configured` in addition if the user does not use the `--destination` parameter.