### PR TITLE
__apt_backports: fix for unstable releases

### DIFF
--- a/type/__apt_backports/manifest
+++ b/type/__apt_backports/manifest
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 #
 # 2020 Matthias Stecher (matthiasstecher at gmx.de)
-# 2022 Dennis Camera (cdist at dtnr.ch)
+# 2022-2023 Dennis Camera (skonfig at dtnr.ch)
 #
 # This file is part of cdist.
 #
@@ -31,24 +31,28 @@ codename_os_release() {
     (. "${__global:?}/explorer/os_release" && printf "%s\n" "${VERSION_CODENAME}")
 }
 
-# detect backport distribution
+join_lines() {
+    sed -e ':a' -e '$!N' -e 's/\n/ /' -e 'ta' "$@"
+}
+
+# detect distribution
 read -r os <"${__global:?}/explorer/os"
 case ${os}
 in
     (debian)
         dist=$(codename_os_release)
         mirror='http://deb.debian.org/debian/'
-        components=$(sed -e ':a' -e '$!N' -e 's/\n/ /' -e 'ta' "${__object:?}/parameter/component")
+        components=$(join_lines "${__object:?}/parameter/component")
         ;;
     (devuan)
         dist=$(codename_os_release)
         mirror='http://deb.devuan.org/merged'
-        components=$(sed -e ':a' -e '$!N' -e 's/\n/ /' -e 'ta' "${__object:?}/parameter/component")
+        components=$(join_lines "${__object:?}/parameter/component")
         ;;
     (ubuntu)
         dist=$(codename_os_release)
         mirror='http://archive.ubuntu.com/ubuntu'
-        components=$(sed -e ':a' -e '$!N' -e 's/\n/ /' -e 'ta' "${__object:?}/parameter/component")
+        components=$(join_lines "${__object:?}/parameter/component")
         ;;
     (*)
         : "${__type:?}"  # make shellcheck happy
@@ -60,7 +64,7 @@ esac
 
 # error if no codename given (e.g. on Debian unstable)
 test -n "${dist}" || {
-    printf "No backports for unkown version of distribution %s!\n" "${os}" >&2
+    printf 'No backports for unkown version of distribution %s!\n' "${os}" >&2
     exit 1
 }
 

--- a/type/__apt_backports/manifest
+++ b/type/__apt_backports/manifest
@@ -22,13 +22,23 @@
 # Enables/disables backports repository. Utilises __apt_source for it.
 #
 
+distro_codename() {
+    # prefer os_release because lsb_release(1) may not be available on all installations,
+    # fall back to lsb_codename if os-release is empty (old versions)
+    if test -s "${__global:?}/explorer/os_release"
+    then
+        # NOTE: only keep the first word of the release, because (at least) Devuan
+        #       adds a suffix for pre-release versions, e.g. "daedalus ceres"
 
-# Get the distribution codename by /etc/os-release.
-#  is already executed in a subshell by string substitution
-#  lsb_release may not be given in all installations
-codename_os_release() {
-    # shellcheck source=/dev/null
-    (. "${__global:?}/explorer/os_release" && printf "%s\n" "${VERSION_CODENAME}")
+        # shellcheck source=/dev/null
+        (. "${__global:?}/explorer/os_release" && printf '%s\n' "${VERSION_CODENAME%% *}")
+    elif test -s "${__global:?}/explorer/lsb_codename"
+    then
+        # shellcheck source=/dev/null
+        cat "${__global:?}/explorer/lsb_codename"
+    else
+        return 1
+    fi
 }
 
 join_lines() {
@@ -40,18 +50,18 @@ read -r os <"${__global:?}/explorer/os"
 case ${os}
 in
     (debian)
-        dist=$(codename_os_release)
         mirror='http://deb.debian.org/debian/'
+        dist=$(distro_codename)
         components=$(join_lines "${__object:?}/parameter/component")
         ;;
     (devuan)
-        dist=$(codename_os_release)
         mirror='http://deb.devuan.org/merged'
+        dist=$(distro_codename)
         components=$(join_lines "${__object:?}/parameter/component")
         ;;
     (ubuntu)
-        dist=$(codename_os_release)
         mirror='http://archive.ubuntu.com/ubuntu'
+        dist=$(distro_codename)
         components=$(join_lines "${__object:?}/parameter/component")
         ;;
     (*)


### PR DESCRIPTION
At least Devuan adds the unstable suffix to the `VERSION_CODENAME` in `/etc/os-release`.
This results in the type creating an APT source with an unexpected name, e.g. `/etc/apt/sources.list.d/daedalus ceres-backports.list`.

This PR fixes this by only using the first word of the codename string.

What is left unsolved is the behaviour on pre-release distributions which don't usually have backports.
Devuan is an exception to this rule. Currently, there is [testing-backports](http://deb.devuan.org/merged/dists/testing-backports/) for Devuan because Debian has released a new version while Devuan has not yet.