### PR TITLE
__rsnyc: Accept shell quoted options in --option(s)

### DIFF
--- a/type/__rsync/gencode-local
+++ b/type/__rsync/gencode-local
@@ -51,6 +51,7 @@ fi
 
 remote_user=$(cat "${__object:?}/parameter/remote-user")
 
+# deprecated parameter
 options=$(cat "${__object:?}/parameter/options")
 
 if [ -f "${__object:?}/parameter/option" ]

--- a/type/__rsync/gencode-local
+++ b/type/__rsync/gencode-local
@@ -1,24 +1,28 @@
 #!/bin/sh -e
 
-if ! command -v rsync > /dev/null
-then
+shquot() {
+sed -e "s/'/'\\\\''/g" -e "1s/^/'/" -e "\$s/\$/'/" <<EOF
+$*
+EOF
+}
+
+command -v rsync >/dev/null 2>&1 || {
     echo 'rsync is missing in local machine' >&2
     exit 1
-fi
+}
 
-src="$( cat "$__object/parameter/source" )"
+src=$(cat "${__object:?}/parameter/source")
 
-if [ ! -e "$src" ]
-then
-    echo "$src not found" >&2
+test -e "${src}" || {
+    echo "${src} not found" >&2
     exit 1
-fi
+}
 
-if [ -f "$__object/parameter/destination" ]
+if [ -f "${__object:?}/parameter/destination" ]
 then
-    dst="$( cat "$__object/parameter/destination" )"
+    dst=$(cat "${__object:?}/parameter/destination")
 else
-    dst="/$__object_id"
+    dst="/${__object_id:?}"
 fi
 
 # if source is directory, then make sure that
@@ -26,24 +30,30 @@ fi
 # because this is what you almost always want when
 # rsyncing two directories.
 
-if [ -d "$src" ]
+if [ -d "${src}" ]
 then
-    if ! echo "$src" | grep -Eq '/$'
-    then
-        src="$src/"
-    fi
+    case ${src}
+    in
+        (*/)
+            ;;
+        (*)
+            src="${src}/" ;;
+    esac
 
-    if ! echo "$dst" | grep -Eq '/$'
-    then
-        dst="$dst/"
-    fi
+    case ${dst}
+    in
+        (*/)
+            ;;
+        (*)
+            dst="${dst}/" ;;
+    esac
 fi
 
-remote_user="$( cat "$__object/parameter/remote-user" )"
+remote_user=$(cat "${__object:?}/parameter/remote-user")
 
-options="$( cat "$__object/parameter/options" )"
+options=$(cat "${__object:?}/parameter/options")
 
-if [ -f "$__object/parameter/option" ]
+if [ -f "${__object:?}/parameter/option" ]
 then
     while read -r l
     do
@@ -51,32 +61,32 @@ then
         # to workaround this, let's prefix opts with '\' in manifest and remove here.
         # read more about argparse issue: https://bugs.python.org/issue9334
 
-        options="$options $( echo "$l" | sed 's/\\//g' )"
+        options="${options} ${l#\\}"
     done \
-        < "$__object/parameter/option"
+        < "${__object:?}/parameter/option"
 fi
 
-if [ -f "$__object/parameter/owner" ] || [ -f "$__object/parameter/group" ]
+if [ -f "${__object:?}/parameter/owner" ] || [ -f "${__object:?}/parameter/group" ]
 then
-    options="$options --chown="
+    options="${options} --chown="
 
-    if [ -f "$__object/parameter/owner" ]
+    if [ -f "${__object:?}/parameter/owner" ]
     then
-        owner="$( cat "$__object/parameter/owner" )"
-        options="$options$owner"
+        owner=$(cat "${__object:?}/parameter/owner")
+        options="${options}$(shquot "${owner}")"
     fi
 
-    if [ -f "$__object/parameter/group" ]
+    if [ -f "${__object:?}/parameter/group" ]
     then
-        group="$( cat "$__object/parameter/group" )"
-        options="$options:$group"
+        group=$(cat "${__object:?}/parameter/group")
+        options="${options}:$(shquot "${group}")"
     fi
 fi
 
-if [ -f "$__object/parameter/mode" ]
+if [ -f "${__object:?}/parameter/mode" ]
 then
-    mode="$( cat "$__object/parameter/mode" )"
-    options="$options --chmod=$mode"
+    mode=$(cat "${__object:?}/parameter/mode")
+    options="${options} --chmod=$(shquot "${mode}")"
 fi
 
 # IMPORTANT
@@ -90,22 +100,30 @@ fi
 # 4. to understand how that cryptic regex works, please
 #    open rsync manpage and read about --itemize-changes.
 
-export RSYNC_RSH="$__remote_exec"
+export RSYNC_RSH="${__remote_exec:?}"
+
+# eval $options into $@ to allow --option to contain quoted shell arguments,
+# e.g. for use with rsync's --filter.
+eval "set -- ${options}"
 
 # shellcheck disable=SC2086
-if ! rsync --dry-run --itemize-changes $options "$src" "$remote_user@$__target_host:$dst" \
-    | grep -E '^(<|>|c|h|\.|\*)[fdL][cstTpogunbax\.\+\?]+\s' >&2
+if ! rsync --dry-run --itemize-changes "$@" "${src}" "${remote_user}@${__target_host:?}:${dst}" \
+    | grep -e '^[<>ch.*][fdLDS][cstTpogunbax.+?]\{9\} ' >&2
 then
     exit 0
 fi
 
-echo "export RSYNC_RSH='$__remote_exec'"
+printf 'export RSYNC_RSH=%s\n' "$(shquot "${__remote_exec:?}")"
+printf 'rsync%s %s %s@%s:%s\n' \
+    "${options:+ ${options# }}" \
+    "$(shquot "${src}")" \
+    "$(shquot "${remote_user}")" \
+    "$(shquot "${__target_host:?}")" \
+    "$(shquot "${dst}")"
 
-echo "rsync $options $src $remote_user@$__target_host:$dst"
-
-if [ -f "$__object/parameter/onchange" ]
+if [ -f "${__object:?}/parameter/onchange" ]
 then
-    cat "$__object/parameter/onchange"
+    cat "${__object:?}/parameter/onchange"
 fi
 
-echo 'synced' >> "$__messages_out"
+echo 'synced' >> "${__messages_out:?}"

--- a/type/__rsync/man.rst
+++ b/type/__rsync/man.rst
@@ -30,6 +30,8 @@ option
    Due to a `bug in Python's argparse<https://bugs.python.org/issue9334>`_,
    the value must be prefixed with ``\``.
 
+   Defaults to: ``--links``, ``--perms``, ``--recursive``, ``--times``
+
 
 OPTIONAL PARAMETERS
 -------------------
@@ -46,10 +48,10 @@ mode
 onchange
    Command to run in target after sync.
 options
-   Defaults to: ``--recursive --links --perms --times``
-
    Due to a `bug in Python's argparse<https://bugs.python.org/issue9334>`_,
    the value must be prefixed with ``\``.
+
+   This parameter is deprecated, please use ``--option`` instead.
 owner
    Will be passed to ``rsync`` as ``--chown=OWNER``.
    Read :strong:`rsync`\ (1) for more details.

--- a/type/__rsync/parameter/default/option
+++ b/type/__rsync/parameter/default/option
@@ -1,0 +1,4 @@
+--links
+--perms
+--recursive
+--times

--- a/type/__rsync/parameter/default/options
+++ b/type/__rsync/parameter/default/options
@@ -1,1 +1,0 @@
---recursive --links --perms --times

--- a/type/__rsync/parameter/deprecated/options
+++ b/type/__rsync/parameter/deprecated/options
@@ -1,0 +1,1 @@
+please use --option instead


### PR DESCRIPTION
Further improved shell quoting and removed unnecessary quotes.

Also, I marked the `--options` parameter as deprecated (it does the same thing as `--option`).