### PR TITLE
__package_apt: quote `--target-release`

### DIFF
--- a/type/__package_apt/gencode-remote
+++ b/type/__package_apt/gencode-remote
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 #
 # 2011-2013 Nico Schottelius (nico-cdist at schottelius.org)
-# 2021 Dennis Camera (cdist at dtnr.ch)
+# 2021,2023 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of cdist.
 #
@@ -32,9 +32,7 @@ state_should=$(cat "${__object:?}/parameter/state")
 version_should=$(cat "${__object:?}/parameter/version" 2>/dev/null) || true
 
 if [ -f "$__object/parameter/target-release" ]; then
-   target_release="--target-release $(cat "$__object/parameter/target-release")"
-else
-   target_release=""
+   target_release=$(cat "$__object/parameter/target-release")
 fi
 
 if [ -f "$__object/parameter/install-recommends" ]; then
@@ -132,7 +130,7 @@ then
 fi
 EOF
 
-        echo "${aptget} ${recommendsparam} install ${target_release} '${name}'"
+        echo "${aptget} ${recommendsparam} install${target_release:+ --target-release '${target_release}'} '${name}'"
         echo 'installed' >>"${__messages_out:?}"
     ;;
     absent)


### PR DESCRIPTION
If a user uses `__package_apt` on Devuan ceres e.g. like this:
```sh
__package_apt foo \
  --target-release "$(cat "${__global:?}/explorer/lsb_codename")-backports
```

It results in the following error message:
```
code-remote:stderr
------------------
E: Unable to locate package ceres-backports
```


The reason for this being that lsb_codename on Devuan ceres contains two words (e.g. `daedalus ceres`).
Word expansion on the target then converted the second word "ceres-backports" into a separate argument which got interpreted by apt-get(8) as the package.

This simple patch quotes the target release, resulting in an error message which makes more sense:
```
code-remote:stderr
------------------
E: The value 'daedalus ceres-backports' is invalid for APT::Default-Release as such a release is not available in the sources
```