### PR TITLE
__download: reduce code duplication, replace `__remote_copy`

### DIFF
--- a/type/__download/explorer/remote_cmd_get
+++ b/type/__download/explorer/remote_cmd_get
@@ -1,16 +1,38 @@
 #!/bin/sh -e
+#
+# 2021 Ander Punnar (ander at kvlt.ee)
+# 2023 Dennis Camera (dennis.camera at riiengineering.ch)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
+# Prints a command available to download files with an unquoted %s format
+# specifier where the URL should be inserted.
+# The downloaded data will be written to stdout.
+#
 
-if [ -f "$__object/parameter/cmd-get" ]
+if test -f "${__object:?}/parameter/cmd-get"
 then
-    cat "$__object/parameter/cmd-get"
-elif
-    command -v curl > /dev/null
+	cat "${__object:?}/parameter/cmd-get"
+elif command -v curl >/dev/null 2>&1
 then
-    echo "curl -sSL -o - '%s'"
-elif
-    command -v fetch > /dev/null
+	echo 'curl -sSL -o - %s'
+elif command -v fetch >/dev/null 2>&1
 then
-    echo "fetch -o - '%s'"
-else
-    echo "wget -q -O - '%s'"
+	echo 'fetch -o - %s'
+elif command -v wget >/dev/null 2>&1
+then
+	echo 'wget -q -O - %s'
 fi

--- a/type/__download/explorer/remote_cmd_sum
+++ b/type/__download/explorer/remote_cmd_sum
@@ -1,82 +1,106 @@
 #!/bin/sh -e
+#
+# 2021 Ander Punnar (ander at kvlt.ee)
+# 2023 Dennis Camera (dennis.camera at riiengineering.ch)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
+# Prints a command available to verify the checksum of a file in the checksum
+# format given in --sum with an unquoted %s format specifier where the file name
+# should be inserted.
+# Nothing will be printed if --sum is not used or no command is available.
+#
 
-if [ ! -f "$__object/parameter/sum" ]
+test -f "${__object:?}/parameter/sum" || exit 0
+
+if test -f "${__object:?}/parameter/cmd-sum"
 then
-    exit 0
+	cat "${__object:?}/parameter/cmd-sum"
+	exit 0
 fi
 
-if [ -f "$__object/parameter/cmd-sum" ]
+if grep -qF ':' "${__object:?}/parameter/sum"
 then
-    cat "$__object/parameter/cmd-sum"
-    exit 0
-fi
-
-sum_should="$( cat "$__object/parameter/sum" )"
-
-if echo "$sum_should" | grep -Fq ':'
-then
-    sum_hash="$( echo "$sum_should" | cut -d : -f 1 )"
+	IFS=: read -r sum_hash sum_should <"${__object:?}/parameter/sum"
 else
-    if echo "$sum_should" | grep -Eq '^[0-9]+\s[0-9]+$'
-    then
-        sum_hash='cksum'
-    elif
-        echo "$sum_should" | grep -Eiq '^[a-f0-9]{32}$'
-    then
-        sum_hash='md5'
-    elif
-        echo "$sum_should" | grep -Eiq '^[a-f0-9]{40}$'
-    then
-        sum_hash='sha1'
-    elif
-        echo "$sum_should" | grep -Eiq '^[a-f0-9]{64}$'
-    then
-        sum_hash='sha256'
-    else
-        echo 'hash format detection failed' >&2
-        exit 1
-    fi
+	sum_should=$(cat "${__object:?}/parameter/sum")
+
+	if expr "${sum_should}" : '[0-9]\{1,\} [0-9]\{1,\}$' >/dev/null
+	then
+		sum_hash='cksum'
+	elif expr "${sum_should}" : '[0-9a-f]\{1,\}$' >/dev/null
+	then
+		case ${#sum_should}
+		in
+			(32)
+				sum_hash='md5' ;;
+			(40)
+				sum_hash='sha1' ;;
+			(64)
+				sum_hash='sha256' ;;
+		esac
+	fi
 fi
 
-os="$( "$__explorer/os" )"
-
-case "$sum_hash" in
-    cksum)
-        echo "cksum %s | awk '{print \$1\" \"\$2}'"
-    ;;
-    md5)
-        case "$os" in
-            freebsd)
-                echo "md5 -q %s"
-            ;;
-            *)
-                echo "md5sum %s | awk '{print \$1}'"
-            ;;
-        esac
-    ;;
-    sha1)
-        case "$os" in
-            freebsd)
-                echo "sha1 -q %s"
-            ;;
-            *)
-                echo "sha1sum %s | awk '{print \$1}'"
-            ;;
-        esac
-    ;;
-    sha256)
-        case "$os" in
-            freebsd)
-                echo "sha256 -q %s"
-            ;;
-            *)
-                echo "sha256sum %s | awk '{print \$1}'"
-            ;;
-        esac
-    ;;
-    *)
-        # we arrive here only if --sum is given with unknown format prefix
-        echo "unknown hash format: $sum_hash" >&2
-        exit 1
-    ;;
+case ${sum_hash}
+in
+	('')
+		echo 'checksum format detection failed' >&2
+		exit 1
+		;;
+	(cksum)
+		# POSIX
+		echo 'cksum <%s'
+		;;
+	(md5)
+		if command -v md5 >/dev/null 2>&1
+		then
+			# BSD
+			echo 'md5 -q %s'
+		elif command -v md5sum >/dev/null 2>&1
+		then
+			# GNU coreutils
+			echo "md5sum %s | awk '{print \$1}'"
+		fi
+		;;
+	(sha1)
+		if command -v sha1 >/dev/null 2>&1
+		then
+			# BSD
+			echo 'sha1 -q %s'
+		elif command -v sha1sum >/dev/null 2>&1
+		then
+			# GNU coreutils
+			echo "sha1sum %s | awk '{print \$1}'"
+		fi
+		;;
+	(sha256)
+		if command -v sha256 >/dev/null 2>&1
+		then
+			# BSD
+			echo 'sha256 -q %s'
+		elif command -v sha256sum >/dev/null 2>&1
+		then
+			# GNU coreutils
+			echo "sha256sum %s | awk '{print \$1}'"
+		fi
+		;;
+	(*)
+		# we arrive here only if --sum is given with unknown format prefix
+		printf 'unknown checksum format: %s\n' "${sum_hash}" >&2
+		exit 1
+		;;
 esac

--- a/type/__download/explorer/state
+++ b/type/__download/explorer/state
@@ -1,45 +1,63 @@
 #!/bin/sh -e
+#
+# 2020-2021 Ander Punnar (ander at kvlt.ee)
+# 2023 Dennis Camera (dennis.camera at riiengineering.ch)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
+# Prints the current state of the destionation file on the target.
+#   "present" if the file exists (and the --sum matches)
+#   "mismatch" if the file exists (and the --sum does not match)
+#   "absent" if the file does not exist
 
-if [ -f "$__object/parameter/destination" ]
+if test -f "${__object:?}/parameter/destination"
 then
-    dst="$( cat "$__object/parameter/destination" )"
+	dst=$(cat "${__object:?}/parameter/destination")
 else
-    dst="/$__object_id"
+	dst="/${__object_id:?}"
 fi
 
-if [ ! -f "$dst" ]
+if test ! -f "${dst}"
 then
-    echo 'absent'
-    exit 0
+	echo 'absent'
+	exit 0
 fi
 
-if [ ! -f "$__object/parameter/sum" ]
+if test ! -f "${__object:?}/parameter/sum"
 then
-    echo 'present'
-    exit 0
+	echo 'present'
+	exit 0
 fi
 
-sum_should="$( cat "$__object/parameter/sum" )"
+sum_should=$(cat "${__object:?}/parameter/sum")
+sum_should=${sum_should#*:}
 
-if echo "$sum_should" | grep -Fq ':'
+sum_cmd=$("${__type_explorer:?}/remote_cmd_sum")
+
+# shellcheck disable=SC2016,SC2059
+sum_is=$(eval " $(printf "${sum_cmd}" '"${dst}"')")
+
+test -n "${sum_is}" || {
+	echo 'existing destination checksum failed' >&2
+	exit 1
+}
+
+if test "${sum_is}" = "${sum_should}"
 then
-    sum_should="$( echo "$sum_should" | cut -d : -f 2 )"
-fi
-
-sum_cmd="$( "$__type_explorer/remote_cmd_sum" )"
-
-# shellcheck disable=SC2059
-sum_is="$( eval "$( printf "$sum_cmd" "'$dst'" )" )"
-
-if [ -z "$sum_is" ]
-then
-    echo 'existing destination checksum failed' >&2
-    exit 1
-fi
-
-if [ "$sum_is" = "$sum_should" ]
-then
-    echo 'present'
+	echo 'present'
 else
-    echo 'mismatch'
+	echo 'mismatch'
 fi

--- a/type/__download/files/common.sh
+++ b/type/__download/files/common.sh
@@ -1,0 +1,101 @@
+# -*- mode: sh; indent-tabs-mode: t -*-
+# shellcheck shell=sh
+#
+# 2023 Dennis Camera (dennis.camera at riiengineering.ch
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
+
+# prepare common variables
+
+if test -f "${__object:?}/parameter/destination"
+then
+	remote_dst=$(cat "${__object:?}/parameter/destination")
+else
+	remote_dst="/${__object_id:?}"
+fi
+
+case ${gencode:-local}
+in
+	(local)
+		cmd_get=$("${__type:?}/explorer/remote_cmd_get")
+		cmd_sum=$("${__type:?}/explorer/remote_cmd_sum")
+		;;
+	(remote)
+		cmd_get=$(cat "${__object:?}/explorer/remote_cmd_get")
+		cmd_sum=$(cat "${__object:?}/explorer/remote_cmd_sum")
+		;;
+	(*)
+		exit 1
+		;;
+esac
+
+
+# functions
+
+shquot() {
+	sed -e "s/'/'\\\\''/g" -e "1s/^/'/" -e "\$s/\$/'/" <<-EOF
+	$*
+	EOF
+}
+
+remote_download_tmp() {
+	# NOTE: this function must always print the same value
+	printf '%s.skonfig__download.tmp\n' "${remote_dst:?}"
+}
+
+gencode_get() (
+	# NOTE: $1 needs to be quoted properly for the target shell
+
+	url=$(cat "${__object:?}/parameter/url")
+
+	test -n "${cmd_get?}" || {
+		echo 'download error: no usable utility' >&2
+		return 1
+	}
+
+	download_tmp=${1:?no download_tmp given}
+
+	# shellcheck disable=SC2059
+	printf "${cmd_get:?} >%s\n" "$(shquot "${url}")" "${download_tmp}"
+)
+
+gencode_cksum() (
+	# NOTE: $1 needs to be quoted properly for the target shell
+
+	test -f "${__object:?}/parameter/sum" || return 0
+
+	file=${1:?no file given}
+
+	sum_should=$(cat "${__object:?}/parameter/sum")
+	sum_should=${sum_should#*:}
+
+	test -n "${cmd_sum?}" || {
+		echo 'checksum verification error: no usable utility' >&2
+		return 1
+	}
+
+	# shellcheck disable=SC2059
+	cat <<-EOF
+	sum_is=\$($(printf "${cmd_sum:?}" "${file}"))
+	if test "\${sum_is}" != $(shquot "${sum_should}")
+	then
+	    printf 'checksum mismatch (%s != %s)\n' "\${sum_is}" $(shquot "${sum_should}") >&2
+	    rm -f ${file}
+	    exit 1
+	fi
+	EOF
+)

--- a/type/__download/gencode-local
+++ b/type/__download/gencode-local
@@ -1,156 +1,62 @@
 #!/bin/sh -e
+#
+# 2020-2022 Ander Punnar (ander at kvlt.ee)
+# 2022 Matthias Stecher (matthiasstecher at gmx.de)
+# 2023 Dennis Camera (dennis.camera at riiengineering.ch)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
 
-download="$( cat "$__object/parameter/download" )"
+gencode=local
+# shellcheck source=SCRIPTDIR/files/common.sh
+. "${__type:?}/files/common.sh"
 
-state_is="$( cat "$__object/explorer/state" )"
+download=$(cat "${__object:?}/parameter/download")
+state_is=$(cat "${__object:?}/explorer/state")
 
-if [ "$download" != 'local' ] || [ "$state_is" = 'present' ]
+test "${state_is}" != 'present' || exit 0
+
+if test "${download}" = 'local'
 then
-    exit 0
+	# shellcheck disable=SC2016
+	echo 'mkdir "${__object:?}/files"'
+
+	# shellcheck disable=SC2016
+	local_download_tmp_q='"${__object:?}/files/download_tmp"'
+	remote_download_tmp=$(remote_download_tmp)
+
+	gencode_get "${local_download_tmp_q}"
+
+	# check local checksum, will be checked again after transfer to remote
+	gencode_cksum "${local_download_tmp_q}"
+
+	if expr "${__target_host:?}" : '[0-9a-fA-F:]\{3,\}$' >/dev/null
+	then
+		target_host="[${__target_host:?}]"
+	else
+		target_host=${__target_host:?}
+	fi
+
+
+	# shellcheck disable=SC2016
+	printf '%s %s %s <%s\n' \
+		"${__remote_exec:?}" \
+		"$(shquot "${target_host}")" \
+		"$(shquot "cat >$(shquot "${remote_download_tmp:?}")")" \
+		"${local_download_tmp_q:?}"
+
+	printf 'rm -f %s\n' "${local_download_tmp_q:?}"
 fi
-
-url="$( cat "$__object/parameter/url" )"
-
-if [ -f "$__object/parameter/destination" ]
-then
-    dst="$( cat "$__object/parameter/destination" )"
-else
-    dst="/$__object_id"
-fi
-
-if [ -f "$__object/parameter/cmd-get" ]
-then
-    cmd="$( cat "$__object/parameter/cmd-get" )"
-
-elif command -v curl > /dev/null
-then
-    cmd="curl -sSL -o - '%s'"
-
-elif command -v fetch > /dev/null
-then
-    cmd="fetch -o - '%s'"
-
-elif command -v wget > /dev/null
-then
-    cmd="wget -q -O - '%s'"
-
-else
-    echo 'local download failed, no usable utility' >&2
-    exit 1
-fi
-
-echo "mkdir \"$__object/files\""
-echo "download_tmp=\"$__object/files/download_tmp\""
-
-# shellcheck disable=SC2059
-printf "$cmd > \"\$download_tmp\"\n" "$url"
-
-if [ -f "$__object/parameter/sum" ]
-then
-    sum_should="$( cat "$__object/parameter/sum" )"
-
-    if [ -f "$__object/parameter/cmd-sum" ]
-    then
-        local_cmd_sum="$( cat "$__object/parameter/cmd-sum" )"
-    else
-        if echo "$sum_should" | grep -Fq ':'
-        then
-            sum_hash="$( echo "$sum_should" | cut -d : -f 1 )"
-
-            sum_should="$( echo "$sum_should" | cut -d : -f 2 )"
-        else
-            if echo "$sum_should" | grep -Eq '^[0-9]+\s[0-9]+$'
-            then
-                sum_hash='cksum'
-            elif
-                echo "$sum_should" | grep -Eiq '^[a-f0-9]{32}$'
-            then
-                sum_hash='md5'
-            elif
-                echo "$sum_should" | grep -Eiq '^[a-f0-9]{40}$'
-            then
-                sum_hash='sha1'
-            elif
-                echo "$sum_should" | grep -Eiq '^[a-f0-9]{64}$'
-            then
-                sum_hash='sha256'
-            else
-                echo 'hash format detection failed' >&2
-                exit 1
-            fi
-        fi
-
-        case "$sum_hash" in
-            cksum)
-                local_cmd_sum="cksum %s | awk '{print \$1\" \"\$2}'"
-            ;;
-            md5)
-                if command -v md5 > /dev/null
-                then
-                    local_cmd_sum="md5 -q %s"
-                elif
-                    command -v md5sum > /dev/null
-                then
-                    local_cmd_sum="md5sum %s | awk '{print \$1}'"
-                fi
-            ;;
-            sha1)
-                if command -v sha1 > /dev/null
-                then
-                    local_cmd_sum="sha1 -q %s"
-                elif
-                    command -v sha1sum > /dev/null
-                then
-                    local_cmd_sum="sha1sum %s | awk '{print \$1}'"
-                fi
-            ;;
-            sha256)
-                if command -v sha256 > /dev/null
-                then
-                    local_cmd_sum="sha256 -q %s"
-                elif
-                    command -v sha256sum > /dev/null
-                then
-                    local_cmd_sum="sha256sum %s | awk '{print \$1}'"
-                fi
-            ;;
-            *)
-                # we arrive here only if --sum is given with unknown format prefix
-                echo "unknown hash format: $sum_hash" >&2
-                exit 1
-            ;;
-        esac
-
-        if [ -z "$local_cmd_sum" ]
-        then
-            echo 'local checksum verification failed, no usable utility' >&2
-            exit 1
-        fi
-    fi
-
-    # shellcheck disable=SC2059
-    echo "sum_is=\"\$( $( printf "$local_cmd_sum" "\"\$download_tmp\"" ) )\""
-
-    echo "if [ \"\$sum_is\" != '$sum_should' ]; then"
-
-    echo "echo 'local download checksum mismatch' >&2"
-
-    echo "rm -f \"\$download_tmp\""
-
-    echo 'exit 1; fi'
-fi
-
-if echo "$__target_host" | grep -Eq '^[0-9a-fA-F:]+$'
-then
-    target_host="[$__target_host]"
-else
-    target_host="$__target_host"
-fi
-
-# shellcheck disable=SC2016
-printf '%s "$download_tmp" %s:%s\n' \
-    "$__remote_copy" \
-    "$target_host" \
-    "$dst"
-
-echo "rm -f \"\$download_tmp\""

--- a/type/__download/gencode-remote
+++ b/type/__download/gencode-remote
@@ -1,59 +1,49 @@
 #!/bin/sh -e
+#
+# 2020-2021 Ander Punnar (ander at kvlt.ee)
+# 2022 Matthias Stecher (matthiasstecher at gmx.de)
+# 2023 Dennis Camera (dennis.camera at riiengineering.ch)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
 
-download="$( cat "$__object/parameter/download" )"
+gencode=remote
+# shellcheck source=SCRIPTDIR/files/common.sh
+. "${__type:?}/files/common.sh"
 
-state_is="$( cat "$__object/explorer/state" )"
+download=$(cat "${__object:?}/parameter/download")
+state_is=$(cat "${__object:?}/explorer/state")
 
-if [ "$download" = 'remote' ] && [ "$state_is" != 'present' ]
+test "${state_is}" != 'present' || exit 0
+
+download_tmp_q=$(shquot "$(remote_download_tmp)")
+
+if test "${download}" = 'remote'
 then
-    cmd_get="$( cat "$__object/explorer/remote_cmd_get" )"
-
-    url="$( cat "$__object/parameter/url" )"
-
-    if [ -f "$__object/parameter/destination" ]
-    then
-        dst="$( cat "$__object/parameter/destination" )"
-    else
-        dst="/$__object_id"
-    fi
-
-    echo "download_tmp=\"${dst}.cdist__download_tmp\""
-
-    # shellcheck disable=SC2059
-    printf "$cmd_get > \"\$download_tmp\"\n" "$url"
-
-    if [ -f "$__object/parameter/sum" ]
-    then
-        sum_should="$( cat "$__object/parameter/sum" )"
-
-        if [ -f "$__object/parameter/cmd-sum" ]
-        then
-            remote_cmd_sum="$( cat "$__object/parameter/cmd-sum" )"
-        else
-            remote_cmd_sum="$( cat "$__object/explorer/remote_cmd_sum" )"
-
-            if echo "$sum_should" | grep -Fq ':'
-            then
-                sum_should="$( echo "$sum_should" | cut -d : -f 2 )"
-            fi
-        fi
-
-        # shellcheck disable=SC2059
-        echo "sum_is=\"\$( $( printf "$remote_cmd_sum" "\"\$download_tmp\"" ) )\""
-
-        echo "if [ \"\$sum_is\" != '$sum_should' ]; then"
-
-        echo "echo 'remote download checksum mismatch' >&2"
-
-        echo "rm -f \"\$download_tmp\""
-
-        echo 'exit 1; fi'
-    fi
-
-    echo "mv \"\$download_tmp\" '$dst'"
+	gencode_get "${download_tmp_q}"
 fi
 
-if [ -f "$__object/parameter/onchange" ] && [ "$state_is" != "present" ]
+# check remote cksum before move to final destination
+gencode_cksum "${download_tmp_q}"
+
+# move file to real destination after cksum check
+printf 'mv %s %s\n' "${download_tmp_q}" "$(shquot "${remote_dst:?}")"
+
+# execute --onchange (both for local and remote download)
+if test -f "${__object:?}/parameter/onchange"
 then
-    cat "$__object/parameter/onchange"
+	cat "${__object:?}/parameter/onchange"
 fi

--- a/type/__download/man.rst
+++ b/type/__download/man.rst
@@ -87,11 +87,12 @@ EXAMPLES
 AUTHORS
 -------
 * Ander Punnar <ander-at-kvlt-dot-ee>
+* Dennis Camera <dennis.camera at riiengineering.ch>
 
 
 COPYING
 -------
-Copyright \(C) 2021 Ander Punnar.
+Copyright \(C) 2021 Ander Punnar; 2023 Dennis Camera.
 You can redistribute it and/or modify it under the terms of the GNU General
 Public License as published by the Free Software Foundation, either version 3 of
 the License, or (at your option) any later version.

--- a/type/__download/manifest
+++ b/type/__download/manifest
@@ -1,6 +1,0 @@
-#!/bin/sh -e
-
-if grep -Eq '^wget' "$__object/explorer/remote_cmd_get"
-then
-    __package wget
-fi


### PR DESCRIPTION
This PR  replaces `__remote_copy` with `__remote_exec` (preparation for skonfig/skonfig#74) in `__download`.

While doing this I noticed that there is some code duplication which I tried to resolve by merging common gencode functionality to download files and check sums into `files/common.sh` and reuse the code in the explorers to also detect `cmd_{get,sum}` for local execution.