### PR TITLE
__ssh_authorized_key: genentry: fix regex for nawk

### DIFF
--- a/type/__ssh_authorized_key/files/genentry.awk
+++ b/type/__ssh_authorized_key/files/genentry.awk
@@ -81,7 +81,7 @@ BEGIN {
 
 	$0 = raw_key
 
-	if (type_and_key !~ /^(ssh|ecdsa|sk)-[^ ]+ AAAA[A-Za-z0-9+/=]+$/) {
+	if (type_and_key !~ /^(ssh|ecdsa|sk)-[^ ]+ AAAA[A-Za-z0-9+\/=]+$/) {
 		exit (e=3)
 	}
 


### PR DESCRIPTION
Unlike gawk and mawk, nawk treats slashes in a character group as the end of a regex.

```console
$ for awk in gawk mawk nawk; do echo $awk:; echo 'ssh-rsa AAAAabc' | $awk '/^ssh-[^ ]+ AAAA[A-Za-z0-9+/=]+$/'; done
gawk:
ssh-rsa AAAAabc
mawk:
ssh-rsa AAAAabc
nawk:
nawk: nonterminated character class ^ssh-[^ ]+ AAAA[A-Za
 source line number 1
 context is
	/^ssh-[^ ]+ >>>  AAAA[A-Za-z0-9+/ <<<
```