### PR TITLE
__start_on_boot: Fix state explorer for OpenRC

### DIFF
--- a/type/__start_on_boot/explorer/state
+++ b/type/__start_on_boot/explorer/state
@@ -78,7 +78,7 @@ else
         gentoo|alpine)
             state="absent"
             for d in /etc/runlevels/*; do
-                if [ -f "/etc/runlevels/${d}/${name}" ];then
+                if [ -e "${d}/${name}" ]; then
                     state="present"
                     break
                 fi


### PR DESCRIPTION
`"/etc/runlevels/${d}/${name}"` expands to `"/etc/runlevels//etc/runlevels/${level}/${name}"`.

Also change `test -f` to `test -e` because `/etc/runlevels` contains symlinks.