### PR TITLE
__pyvenv: Don't ls a non-existing directory

### DIFF
--- a/type/__pyvenv/explorer/group
+++ b/type/__pyvenv/explorer/group
@@ -2,6 +2,8 @@
 
 destination="/${__object_id:?}"
 
+test -d "${destination}" || exit 0
+
 # shellcheck disable=SC2012
 group_gid=$(ls -ldn "${destination}" | awk '{ print $4 }')
 

--- a/type/__pyvenv/explorer/group
+++ b/type/__pyvenv/explorer/group
@@ -1,4 +1,25 @@
 #!/bin/sh -e
+#
+# 2016 Darko Poljak (darko.poljak at gmail.com)
+# 2021,2023 Dennis Camera (dennis.camera at riiengineering.ch)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
+# Prints the group owning the virtual env directory if it exists already.
+#
 
 destination="/${__object_id:?}"
 

--- a/type/__pyvenv/explorer/owner
+++ b/type/__pyvenv/explorer/owner
@@ -2,6 +2,8 @@
 
 destination="/${__object_id:?}"
 
+test -d "${destination}" || exit 0
+
 # shellcheck disable=SC2012
 owner_uid=$(ls -ldn "${destination}" | awk '{ print $3 }')
 

--- a/type/__pyvenv/explorer/owner
+++ b/type/__pyvenv/explorer/owner
@@ -1,4 +1,25 @@
 #!/bin/sh -e
+#
+# 2016 Darko Poljak (darko.poljak at gmail.com)
+# 2021,2023 Dennis Camera (dennis.camera at riiengineering.ch)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
+# Prints the owner of the virtual env directory if it exists already.
+#
 
 destination="/${__object_id:?}"
 

--- a/type/__pyvenv/explorer/state
+++ b/type/__pyvenv/explorer/state
@@ -1,9 +1,35 @@
-#!/bin/sh
+#!/bin/sh -e
+#
+# 2016 Darko Poljak (darko.poljak at gmail.com)
+# 2023 Dennis Camera (dennis.camera at riiengineering.ch)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
+# Prints the current state of the venv.
+#
+# NB: this explorer does not currently check if the directory contains a
+# virtual env and if it is valid (e.g. the bin/python) link points to an existing
+# Python interpreter (e.g. after a system upgrade).
+#
 
-destination="/$__object_id"
+destination="/${__object_id:?}"
 
-if [ -d "$destination" ]; then
-   echo present
+if test -d "${destination}"
+then
+	echo present
 else
-   echo absent
+	echo absent
 fi

--- a/type/__pyvenv/gencode-remote
+++ b/type/__pyvenv/gencode-remote
@@ -3,20 +3,20 @@
 # 2016 Darko Poljak (darko.poljak at gmail.com)
 # 2020 Nico Schotetlius (nico.schottelius at ungleich.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 

--- a/type/__pyvenv/manifest
+++ b/type/__pyvenv/manifest
@@ -2,20 +2,20 @@
 #
 # 2016 Darko Poljak (darko.poljak at gmail.com)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 # It assumes pyvenv is already installed. Concrete packages


### PR DESCRIPTION
Just a little patch to check if the venv directory exists before trying to run `ls(1)` on in in the `owner` and `group` explorers.

Also, while in there I added missing copyright headers and updated the exsting ones.