### PR TITLE
__apt_pin: Add `--origin`, `--release`, `--version` parameters

### DIFF
--- a/type/__apt_pin/man.rst
+++ b/type/__apt_pin/man.rst
@@ -3,37 +3,83 @@ cdist-type__apt_pin(7)
 
 NAME
 ----
-cdist-type__apt_pin - Manage apt pinning rules
+cdist-type__apt_pin - Manage APT pinning rules
 
 
 DESCRIPTION
 -----------
-Adds/removes/edits rules to pin some packages to a specific distribution. Useful
-if using multiple debian repositories at the same time. (Useful, if one wants to
-use a few specific packages from backports or perhaps Debain testing... or even
-sid.)
+Manage the priorities of APT packages based on the package version,
+the repository they come from, or the repository server.
+This is commonly called "pinning".
 
-
-REQUIRED PARAMETERS
--------------------
-distribution
-   Specifies what distribution the package should be pinned to. Accepts both
-   codenames (buster/bullseye/sid) and suite names (stable/testing/...).
+When packages are contained in multiple repositories, pinning becomes useful to
+specify which sources APT should install packages from (e.g. backports or
+vendor repositories).
 
 
 OPTIONAL PARAMETERS
 -------------------
-package
-   Package name, glob or regular expression to match (multiple) packages.
+description
+   A description to be added as a comment to the pin configuration.
 
-   Defaults to: ``__objet_id``
+   Defaults to: ``__object_id``
+distribution
+   Specifies what distribution the package should be pinned to.
+
+   Accepts both codenames (e.g. ``buster``, ``bullseye``, ``sid``) and
+   suite names (``stable``, ``oldstable``, ``testing``, ...).
+
+   **NB:** This parameter is kept for backwards compatibility.
+   It is better to use ``--release`` instead, as it is more flexible and does
+   not rely on this type differentiating archive and code names correctly.
+
+   If ``--origin``, ``--release``, or ``--version`` is used, this parameter will
+   be silently ignored.
+origin
+   Pin ``--package`` to the specified origin (=hostname).
+
+   The value will be automatically quoted.
+   An empty value means "the local site".
+
+   Do not confuse ``--origin`` with the ``Origin`` of a distribution as
+   specified in a repository Release file.
+
+   This parameter is mutually exclusive with ``--release`` and ``--version``.
+package
+   The package(s) this pin applies to.
+
+   Can be a
+   * package name,
+   * glob,
+   * regular expression (ERE) (wrapped in `/.../`), or
+   * a source package name (`src:...`).
+
+   For more details cf. :strong:`apt_preferences`\ (5).
+
+   Can be used multiple times to specify multiple packages for this pin.
+
+   Defaults to: ``__object_id``
 priority
    The priority value to assign to matching packages.
 
-   Defaults to: 500 (to match the default target distro's priority)
+   Defaults to: 500 (to match the default target release's priority)
+release
+   Pin ``--package`` to the specified release.
+
+   The release can filter distributions by various Release properties,
+   cf. :strong:`apt_preferences`\ (5) for more details.
+
+   This parameter is mutually exclusive with ``--origin`` and ``--version``.
 state
-   Will be passed to underlying ``__file`` type; see there for valid values and
-   defaults.
+   Will be passed to the underlying :strong:`cdist-type__file`\ (7) object.
+
+   Can be any value `__file --state`` accepts.
+
+   Defaults to: ``present``
+version
+   Pin ``--package`` to the specified package version.
+
+   This parameter is mutually exclusive with ``--origin`` and ``--release``.
 
 
 EXAMPLES
@@ -42,25 +88,35 @@ EXAMPLES
 .. code-block:: sh
 
    # Add the bullseye repo to buster, but do not install any packages by default
-   # only if explicitly asked for (-1 means "never" for apt)
+   # only if explicitly asked for (-1 means "never")
    __apt_pin bullseye-default \
       --package '*' \
-      --distribution bullseye \
+      --release 'n=bullseye' \
       --priority -1
-
    require=__apt_pin/bullseye-default \
    __apt_source bullseye \
-      --uri http://deb.debian.org/debian/ \
-      --distribution bullseye \
+      --uri 'http://deb.debian.org/debian/' \
+      --release 'n=bullseye' \
       --component main
 
+   # install foo from bullseye distribution
    __apt_pin foo \
-      --package "foo foo-*" \
-      --distribution bullseye
+      --package 'foo foo-*' \
+      --release 'n=bullseye'
+   require=__apt_pin/foo \
+   __package foo
 
-    __foo  # assuming, this installs the `foo` package internally
+   # enforce ejabberd version 23.01
+   __apt_pin ejabberd \
+      --package 'src:ejabberd' \
+      --version '23.01*' \
+      --priority 1000
 
-    __package foo-plugin-extras  # assuming we also need some extra stuff
+   # prefer packages from example.com repository
+   __apt_pin ownrepo \
+      --package '**' \
+      --origin 'deb.example.com' \
+      --priority 600
 
 
 SEE ALSO
@@ -73,12 +129,13 @@ SEE ALSO
 
 AUTHORS
 -------
-* Daniel Fancsali <fancsali@gmail.com>
+* Daniel Fancsali <fancsali--@--gmail.com>
+* Dennis Camera <dennis.camera--@--riiengineering.ch>
 
 
 COPYING
 -------
-Copyright \(C) 2021 Daniel Fancsali.
+Copyright \(C) 2021 Daniel Fancsali, 2024 Dennis Caemra.
 You can redistribute it and/or modify it under the terms of the GNU General
 Public License as published by the Free Software Foundation, either version 3 of
 the License, or (at your option) any later version.

--- a/type/__apt_pin/manifest
+++ b/type/__apt_pin/manifest
@@ -1,68 +1,127 @@
 #!/bin/sh -e
 #
-# 2021 Daniel Fancsali (fancsali@gmail.com)
+# 2021 Daniel Fancsali (fancsali at gmail.com)
+# 2024 Dennis Camera (dennis.camera at riiengineering.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
+join_lines() {
+	sed -e ':a' -e '$!N' -e 's/\n/ /' -e 'ta' "$@"
+}
 
-name="$__object_id"
+param_numexist() {
+	for __p
+	do
+		if test -f "${__object:?}/parameter/${__p}"
+		then
+			set -- "$@" "${__p}"
+		fi
+		shift
+	done
+	unset -v __p
+	echo $#
+}
 
-os=$(cat "$__global/explorer/os")
-state="$(cat "$__object/parameter/state")"
 
-if [ -f "$__object/parameter/package" ]; then
-    package="$(cat "$__object/parameter/package")"
+os=$(cat "${__global:?}/explorer/os")
+case ${os}
+in
+	(debian|ubuntu|devuan)
+		;;
+	(*)
+		printf 'This type is specific to Debian and its derivatives.' >&2
+		exit 1
+		;;
+esac
+
+
+read -r state <"${__object:?}/parameter/state"
+priority=$(( $(cat "${__object:?}/parameter/priority") ))
+
+if test -f "${__object:?}/parameter/package"
+then
+	package=$(join_lines "${__object:?}/parameter/package")
 else
-    package=$name
+	package=${__object_id:?}
 fi
 
-distribution="$(cat "$__object/parameter/distribution")"
-priority="$(cat "$__object/parameter/priority")"
+if test -f "${__object:?}/parameter/description"
+then
+	description=$(sed -e 's/^/# /' "${__object:?}/parameter/description")
+else
+	description="# ${__object_id:?}"
+fi
 
 
-case "$os" in
-   debian|ubuntu|devuan)
-   ;;
-   *)
-      printf "This type is specific to Debian and it's derivatives" >&2
-      exit 1
-   ;;
+
+case $(param_numexist origin release version)
+in
+	(0)
+		if test -f "${__object:?}/parameter/distribution"
+		then
+			distribution=$(cat "${__object:?}/parameter/distribution")
+
+			case ${distribution}
+			in
+				(oldoldstable|oldstable|stable|testing|unstable|experimental)
+					pin="release a=${distribution}"
+					;;
+				(oldoldstable-*|oldstable-*|stable-*|testing-*|unstable-*|experimental-*)
+					pin="release a=${distribution}"
+					;;
+				(*)
+					pin="release n=${distribution}"
+					;;
+			esac
+		else
+			printf 'No pin parameter used. Use one of --origin, --release, --version, or --distribution.\n' >&2
+			exit 1
+		fi
+		;;
+	(1)
+		if test -f "${__object:?}/parameter/origin"
+		then
+			read -r pin_origin <"${__object:?}/parameter/origin"
+			pin="origin \"${pin_origin}\""
+		elif test -f "${__object:?}/parameter/release"
+		then
+			read -r pin_release <"${__object:?}/parameter/release"
+			pin="release ${pin_release}"
+		elif test -f "${__object:?}/parameter/version"
+		then
+			read -r pin_version <"${__object:?}/parameter/version"
+			pin="version ${pin_version}"
+		fi
+		;;
+	(*)
+		printf 'The parameters --origin, --release, and --version are mutually exclusive. Use only one of them.\n' >&2
+		exit 1
+		;;
 esac
 
-case $distribution in
-    stable|testing|unstable|experimental)
-        pin="release a=$distribution"
-        ;;
-    *)
-        pin="release n=$distribution"
-        ;;
-esac
+__file "/etc/apt/preferences.d/${__object_id:?}" \
+	--owner 0 --group 0 --mode 0644 \
+	--state "${state}" \
+	--source - <<EOF
+# This file is managed by skonfig (${__type##*/})
+# Changes will be overwritten.
 
-
-__file "/etc/apt/preferences.d/$name" \
-    --owner root --group root --mode 0644 \
-    --state "$state" \
-    --source - << EOF
-# Created by cdist ${__type##*/}
-# Do not change. Changes will be overwritten.
-#
-
-# $name
-Package: $package
-Pin: $pin
-Pin-Priority: $priority
+# ${description#\# }
+Package: ${package}
+Pin: ${pin}
+Pin-Priority: ${priority}
 EOF

--- a/type/__apt_pin/parameter/optional
+++ b/type/__apt_pin/parameter/optional
@@ -1,3 +1,7 @@
-state
-package
+description
+distribution
+origin
 priority
+release
+state
+version

--- a/type/__apt_pin/parameter/optional_multiple
+++ b/type/__apt_pin/parameter/optional_multiple
@@ -1,0 +1,1 @@
+package

--- a/type/__apt_pin/parameter/required
+++ b/type/__apt_pin/parameter/required
@@ -1,1 +1,0 @@
-distribution


### PR DESCRIPTION
An almost complete rewrite of `__apt_pin`.

Instead of having `--distribution` try to differentiate suite and code names (sometimes incorrectly, e.g. `oldstable`, `stable-backports`), I added the new parameters `--origin`, `--release`, and `--version` which correspond to the three options `apt_preferences(5)` supports.

Other small changes:
* added `--description`
* cdist -> skonfig
* removed `nonparallel` (don't see why it is needed)