### PR TITLE
__package_apt: only check rprovides if requested state is "present"

### DIFF
--- a/type/__package_apt/explorer/state
+++ b/type/__package_apt/explorer/state
@@ -41,11 +41,16 @@ else
 	name=${__object_id:?}
 fi
 
+state=$(cat "${__object:?}/parameter/state")
+
+# if present state is requested and $name is e.g. editor, check if any editor is installed instead
+if [ "$state" = 'present' ]
+then
+	rprovides=$(apt-cache showpkg "${name}" | sed -e '1,/^Reverse Provides:/d' -e 's/ .*$//')
+fi
+
 state_dir=$(apt-config dump | sed -n -e 's/^Dir::State  *"\(.*\)";$/\/\1/p')
 extended_states_file=${state_dir%/}/extended_states
-
-# if $name is e.g. editor, check if any editor is installed instead
-rprovides=$(apt-cache showpkg "${name}" | sed -e '1,/^Reverse Provides:/d' -e 's/ .*$//')
 
 for pkg in ${name} ${rprovides}
 do


### PR DESCRIPTION
When trying to remove already absent package which has reverse provides defined, and reverse provide is installed, then that gets removed.

For example with vim:
```
$ dpkg -l | awk '/vim/ {print $2}'
vim-common
vim-gtk3
vim-gui-common
vim-runtime
$ echo __package_apt vim --state absent | skonfig localhost -i - -n 
INFO: localhost: Starting dry run
INFO: localhost: Processing __package_apt/vim
INFO: localhost: Finished dry run in 1.44 seconds
$ skonfig -d localhost | grep code-remote
object/__package_apt/vim/.cdist-r4dzn92m/code-remote: DEBIAN_FRONTEND=noninteractive apt-get --quiet --yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" remove  'vim-gtk3'
```

Proposed change fixes this.