### PR TITLE
__clean_path: update man.rst

### DIFF
--- a/type/__clean_path/man.rst
+++ b/type/__clean_path/man.rst
@@ -70,6 +70,10 @@ EXAMPLES
 
 .. code-block:: sh
 
+   # delete everything inside a directory
+   __clean_path /tmp/very.temp
+
+
    # Debian: disable all apache2 conf's other than charset.conf and security.conf
 
    __clean_path /etc/apache2/conf-enabled \

--- a/type/__clean_path/man.rst
+++ b/type/__clean_path/man.rst
@@ -61,7 +61,7 @@ not-path
     Same as :strong:`find`\ (1)'s ``! -path``.
 not-regex
     Same as :strong:`find`\ (1)'s ``! -regex`` (not POSIX).
-rm-type
+not-type
     Same as :strong:`find`\ (1)'s ``! -type``.
 
 


### PR DESCRIPTION
Fixed a typo (parameter `not-type` was incorrectly called `rm-type`) and added an example to clear everything inside a given directory (I think it was not entirely clear how to do so just by reading the man page).