### PR TITLE
__rsync: Be flexible in the length of `--itemize-changes` output

### DIFF
--- a/type/__rsync/gencode-local
+++ b/type/__rsync/gencode-local
@@ -117,7 +117,7 @@ eval "set -- ${options}"
 
 # shellcheck disable=SC2086
 if ! rsync --dry-run --itemize-changes "$@" "${src}" "${remote_user}@${__target_host:?}:${dst}" \
-    | grep -e '^[<>ch.*][fdLDS][cstTpogunbax.+?]\{9\} ' >&2
+    | grep -e '^[<>ch.*][fdLDS][cstTpogunbax.+?]\{7,\} ' -e '^\*deleting ' >&2
 then
     exit 0
 fi


### PR DESCRIPTION
Different versions of rsync output different lengths of `--itemize-changes` lists.

Also, catch the special form "*deleting".

e.g. on macOS:

2.6.9

    *deleting xyz
    .d..t.... ./
    <f+++++++ foo

3.2.1-3.2.2

    *deleting   xyz
    .d..t........ ./
    <f+++++++++++ foo

3.2.3-3.3.0

    *deleting   xyz
    .d..t....... ./
    <f++++++++++ foo