### PR TITLE
Drop is-freebsd-jail explorer

### DIFF
--- a/explorer/is-freebsd-jail
+++ b/explorer/is-freebsd-jail
@@ -1,2 +1,0 @@
-#!/bin/sh
-sysctl -n security.jail.jailed 2>/dev/null | grep "1" || true


### PR DESCRIPTION
The explorer is likely unused in 99% of all cases. It's certainly not used by any upstream types.

Futhermore, the same information can be extracted from the machine_type explorer:

```sh
grep jail "${__global:?}/explorer/machine_type"
```