### PR TITLE
Update copyright headers

### DIFF
--- a/explorer/cpu_cores
+++ b/explorer/cpu_cores
@@ -1,22 +1,22 @@
 #!/bin/sh
 #
-# 2014 Daniel Heule  (hda at sfs.biz)
+# 2014 Daniel Heule (hda at sfs.biz)
 # 2014 Thomas Oettli (otho at sfs.biz)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 

--- a/explorer/cpu_cores
+++ b/explorer/cpu_cores
@@ -18,7 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
 
 # FIXME: other system types (not linux ...)
 

--- a/explorer/cpu_cores
+++ b/explorer/cpu_cores
@@ -18,6 +18,9 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints the number of CPU cores available on the target.
+# Note that this number includes virtual SMT threads.
+#
 
 # FIXME: other system types (not linux ...)
 

--- a/explorer/cpu_sockets
+++ b/explorer/cpu_sockets
@@ -18,6 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints the number of CPU sockets in use on the target.
+#
 
 # FIXME: other system types (not linux ...)
 

--- a/explorer/cpu_sockets
+++ b/explorer/cpu_sockets
@@ -1,22 +1,22 @@
 #!/bin/sh
 #
-# 2014 Daniel Heule  (hda at sfs.biz)
+# 2014 Daniel Heule (hda at sfs.biz)
 # 2014 Thomas Oettli (otho at sfs.biz)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 

--- a/explorer/cpu_sockets
+++ b/explorer/cpu_sockets
@@ -18,7 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
 
 # FIXME: other system types (not linux ...)
 

--- a/explorer/disks
+++ b/explorer/disks
@@ -19,6 +19,7 @@
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 # Finds disks of the system (excl. ram disks, floppy, cdrom)
+#
 
 uname_s=$(uname -s)
 

--- a/explorer/disks
+++ b/explorer/disks
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 #
 # based on previous work by other people, modified by:
-# 2020,2022,2023 Dennis Camera <dennis.camera at riiengineering.ch>
+# 2020,2022-2023 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/explorer/disks
+++ b/explorer/disks
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-# Finds disks of the system (excl. ram disks, floppy, cdrom)
+# Finds disks of the system (excl. RAM disks, floppy, CDROM).
 #
 
 uname_s=$(uname -s)

--- a/explorer/hostname
+++ b/explorer/hostname
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
 # Retrieve the running hostname
 #
 

--- a/explorer/hostname
+++ b/explorer/hostname
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# 2019 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2019 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/explorer/hostname
+++ b/explorer/hostname
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-# Retrieve the running hostname
+# Prints the running hostname.
 #
 
 if command -v hostname >/dev/null

--- a/explorer/hostname
+++ b/explorer/hostname
@@ -2,20 +2,20 @@
 #
 # 2019 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Retrieve the running hostname

--- a/explorer/init
+++ b/explorer/init
@@ -1,23 +1,23 @@
 #!/bin/sh -e
 #
 # 2016 Daniel Heule (hda at sfs.biz)
-# Copyright 2017, Philippe Gregoire <pg@pgregoire.xyz>
+# 2017 Philippe Gregoire (pg at pgregoire.xyz)
 # 2020,2023 Dennis Camera (dennis.camera at riiengineering.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Returns the name of the init system (PID 1)

--- a/explorer/init
+++ b/explorer/init
@@ -19,9 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
 # Returns the name of the init system (PID 1)
-
+#
 # Expected values:
 # Linux:
 #  Adélie Linux:
@@ -68,6 +67,7 @@
 #
 # Solaris/Illumos:
 #   smf, init???
+#
 
 # NOTE: init systems can be stacked. This is popular to run OpenRC on top of
 # sysvinit (Gentoo) or busybox-init (Alpine), but can also be used to run runit

--- a/explorer/interfaces
+++ b/explorer/interfaces
@@ -17,6 +17,10 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Lists all network interfaces available on the target.
+# One interface name per line.
+# Output is sorted lexicographically.
+#
 
 if command -v ip >/dev/null
 then

--- a/explorer/interfaces
+++ b/explorer/interfaces
@@ -1,21 +1,21 @@
 #!/bin/sh -e
 #
-# 2019 Ander Punnar (ander-at-kvlt-dot-ee)
+# 2019 Ander Punnar (ander at kvlt.ee)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 if command -v ip >/dev/null

--- a/explorer/kernel_name
+++ b/explorer/kernel_name
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-# Print the kernel name as reported by uname(1).
+# Prints the kernel name as reported by uname(1).
 #
 
 uname -s

--- a/explorer/kernel_name
+++ b/explorer/kernel_name
@@ -1,2 +1,23 @@
 #!/bin/sh
+#
+# 2017 Kamila Souckova (kamila at ksp.sk)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
+# Print the kernel name as reported by uname(1).
+#
+
 uname -s

--- a/explorer/lsb_codename
+++ b/explorer/lsb_codename
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
 
 set +e
 case "$("$__explorer/os")" in

--- a/explorer/lsb_codename
+++ b/explorer/lsb_codename
@@ -2,20 +2,20 @@
 #
 # 2011 Steven Armstrong (steven-cdist at armstrong.cc)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 

--- a/explorer/lsb_codename
+++ b/explorer/lsb_codename
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints the LSB codename.
+#
 
 set +e
 case "$("$__explorer/os")" in

--- a/explorer/lsb_description
+++ b/explorer/lsb_description
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints the LSB description.
+#
 
 set +e
 case "$("$__explorer/os")" in

--- a/explorer/lsb_description
+++ b/explorer/lsb_description
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
 
 set +e
 case "$("$__explorer/os")" in

--- a/explorer/lsb_description
+++ b/explorer/lsb_description
@@ -2,20 +2,20 @@
 #
 # 2011 Steven Armstrong (steven-cdist at armstrong.cc)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 

--- a/explorer/lsb_id
+++ b/explorer/lsb_id
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints the LSB ID.
+#
 
 set +e
 case "$("$__explorer/os")" in

--- a/explorer/lsb_id
+++ b/explorer/lsb_id
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
 
 set +e
 case "$("$__explorer/os")" in

--- a/explorer/lsb_id
+++ b/explorer/lsb_id
@@ -2,20 +2,20 @@
 #
 # 2011 Steven Armstrong (steven-cdist at armstrong.cc)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 

--- a/explorer/lsb_release
+++ b/explorer/lsb_release
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints the LSB release.
+#
 
 set +e
 case "$("$__explorer/os")" in

--- a/explorer/lsb_release
+++ b/explorer/lsb_release
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
 
 set +e
 case "$("$__explorer/os")" in

--- a/explorer/lsb_release
+++ b/explorer/lsb_release
@@ -2,20 +2,20 @@
 #
 # 2011 Steven Armstrong (steven-cdist at armstrong.cc)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 

--- a/explorer/machine
+++ b/explorer/machine
@@ -2,24 +2,22 @@
 #
 # 2010-2011 Andi Brönnimann (andi-cdist at v-net.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# All os variables are lower case
-#
+# Prints the processor architecture of the target.
 #
 
 if command -v uname >/dev/null 2>&1 ; then

--- a/explorer/machine_type
+++ b/explorer/machine_type
@@ -2,20 +2,20 @@
 #
 # 2021,2023 Dennis Camera (dennis.camera at riiengineering.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 # This explorer tries to determine what type of machine the target to be
 # configured is (container, virtual machine, bare-metal).

--- a/explorer/memory
+++ b/explorer/memory
@@ -1,24 +1,24 @@
 #!/bin/sh -e
 #
-# 2014 Daniel Heule  (hda at sfs.biz)
+# 2014 Daniel Heule (hda at sfs.biz)
 # 2014 Thomas Oettli (otho at sfs.biz)
-# Copyright 2017, Philippe Gregoire <pg@pgregoire.xyz>
-# 2020 Dennis Camera <dennis.camera at ssrq-sds-fds.ch>
+# 2017 Philippe Gregoire (pg at pgregoire.xyz)
+# 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 # Returns the amount of memory physically installed in the system, or if that
 # cannot be determined the amount available to the operating system kernel,

--- a/explorer/memory
+++ b/explorer/memory
@@ -23,6 +23,7 @@
 # Returns the amount of memory physically installed in the system, or if that
 # cannot be determined the amount available to the operating system kernel,
 # in kibibytes (kiB).
+#
 
 str2bytes() {
 	awk -F' ' '

--- a/explorer/memory
+++ b/explorer/memory
@@ -3,7 +3,7 @@
 # 2014 Daniel Heule (hda at sfs.biz)
 # 2014 Thomas Oettli (otho at sfs.biz)
 # 2017 Philippe Gregoire (pg at pgregoire.xyz)
-# 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2020 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/explorer/memory
+++ b/explorer/memory
@@ -20,7 +20,7 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-# Returns the amount of memory physically installed in the system, or if that
+# Prints the amount of memory physically installed in the system, or if that
 # cannot be determined the amount available to the operating system kernel,
 # in kibibytes (kiB).
 #

--- a/explorer/os
+++ b/explorer/os
@@ -19,7 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-# All os variables are lower case.
+# Prints an identifier for the OS running on the target.
+# All values are lower case.
 #
 
 

--- a/explorer/os
+++ b/explorer/os
@@ -1,23 +1,23 @@
 #!/bin/sh
 #
 # 2010-2011 Nico Schottelius (nico-cdist at schottelius.org)
-# Copyright 2017, Philippe Gregoire <pg@pgregoire.xyz>
-# 2019,2020,2023 Dennis Camera (dennis.camera at riiengineering.ch)
+# 2017 Philippe Gregoire (pg at pgregoire.xyz)
+# 2019-2020,2023 Dennis Camera (dennis.camera at riiengineering.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 # All os variables are lower case.
 # Operating systems are grouped into sections, with more popular ones

--- a/explorer/os
+++ b/explorer/os
@@ -20,10 +20,12 @@
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 # All os variables are lower case.
+#
+
+
 # Operating systems are grouped into sections, with more popular ones
 # further up, except in cases where correct detection depends on a specific
 # order.
-#
 
 if [ -f /etc/cdist-preos ]; then
    echo cdist-preos

--- a/explorer/os_release
+++ b/explorer/os_release
@@ -3,20 +3,20 @@
 # 2018 Adam Dej (dejko.a at gmail.com)
 # 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 

--- a/explorer/os_release
+++ b/explorer/os_release
@@ -18,9 +18,10 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints the contents of the os-release(5) file.
 #
-
-# See os-release(5) and http://0pointer.de/blog/projects/os-release
+# cf. os-release(5) and http://0pointer.de/blog/projects/os-release
+#
 
 if test -f /etc/os-release
 then

--- a/explorer/os_release
+++ b/explorer/os_release
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 # 2018 Adam Dej (dejko.a at gmail.com)
-# 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2020 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/explorer/os_version
+++ b/explorer/os_version
@@ -3,20 +3,20 @@
 # 2010-2011 Nico Schottelius (nico-cdist at schottelius.org)
 # 2020-2023 Dennis Camera (dennis.camera at riiengineering.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 # All os variables are lower case
 #

--- a/explorer/os_version
+++ b/explorer/os_version
@@ -18,7 +18,10 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-# All os variables are lower case
+# Prints the OS version installed on the target.
+#
+# NB: the output varies across different operating systems and is not normalized
+# in any way.
 #
 
 rc_getvar() {

--- a/explorer/runlevel
+++ b/explorer/runlevel
@@ -2,20 +2,20 @@
 #
 # 2012 Nico Schottelius (nico-cdist at schottelius.org)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 

--- a/explorer/runlevel
+++ b/explorer/runlevel
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
 
 set +e
 executable=$(command -v runlevel)

--- a/explorer/runlevel
+++ b/explorer/runlevel
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints the runlevel the target is currently running in.
+#
 
 set +e
 executable=$(command -v runlevel)

--- a/type/__acl/explorer/acl_is
+++ b/type/__acl/explorer/acl_is
@@ -17,6 +17,10 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints the existing ACLs of the destination file.
+#
+# Raises an error if the getfacl(1) command is not available.
+#
 
 [ ! -e "/$__object_id" ] && exit 0
 

--- a/type/__acl/explorer/acl_is
+++ b/type/__acl/explorer/acl_is
@@ -1,21 +1,21 @@
 #!/bin/sh -e
 #
-# 2018 Ander Punnar (ander-at-kvlt-dot-ee)
+# 2018 Ander Punnar (ander at kvlt.ee)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 [ ! -e "/$__object_id" ] && exit 0

--- a/type/__acl/explorer/file_is
+++ b/type/__acl/explorer/file_is
@@ -1,21 +1,21 @@
 #!/bin/sh -e
 #
-# 2018 Ander Punnar (ander-at-kvlt-dot-ee)
+# 2018 Ander Punnar (ander at kvlt.ee)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 if [ -e "/$__object_id" ]

--- a/type/__acl/explorer/file_is
+++ b/type/__acl/explorer/file_is
@@ -17,6 +17,10 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints the current state of the destination file.
+#
+# One of: directory, regular, other, missing.
+#
 
 if [ -e "/$__object_id" ]
 then

--- a/type/__acl/explorer/getent
+++ b/type/__acl/explorer/getent
@@ -1,4 +1,22 @@
 #!/bin/sh -e
+#
+# 2020 Ander Punnar (ander at kvlt.ee)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
 
 getent passwd | awk -F: '{print "user:"$1}'
 getent group | awk -F: '{print "group:"$1}'

--- a/type/__acl/explorer/getent
+++ b/type/__acl/explorer/getent
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints all users and groups currently known to the system.
+#
 
 getent passwd | awk -F: '{print "user:"$1}'
 getent group | awk -F: '{print "group:"$1}'

--- a/type/__acl/gencode-remote
+++ b/type/__acl/gencode-remote
@@ -1,21 +1,21 @@
 #!/bin/sh -e
 #
-# 2018 Ander Punnar (ander-at-kvlt-dot-ee)
+# 2018 Ander Punnar (ander at kvlt.ee)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 file_is="$( cat "$__object/explorer/file_is" )"

--- a/type/__acl/man.rst
+++ b/type/__acl/man.rst
@@ -98,7 +98,7 @@ EXAMPLES
 
 AUTHORS
 -------
-* Ander Punnar <ander-at-kvlt-dot-ee>
+* Ander Punnar <ander--@--kvlt.ee>
 
 
 COPYING

--- a/type/__acl/manifest
+++ b/type/__acl/manifest
@@ -1,4 +1,22 @@
 #!/bin/sh -e
+#
+# 2020 Ander Punnar (ander at kvlt.ee)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
 
 for p in file directory
 do

--- a/type/__apt_backports/man.rst
+++ b/type/__apt_backports/man.rst
@@ -66,7 +66,7 @@ SEE ALSO
 AUTHORS
 -------
 * Matthias Stecher <matthiasstecher--@--gmx.de>
-* Dennis Camera <skonfig--@--dtnr.ch>
+* Dennis Camera <dennis.camera--@--riiengineering.ch>
 
 
 COPYING

--- a/type/__apt_backports/man.rst
+++ b/type/__apt_backports/man.rst
@@ -66,7 +66,7 @@ SEE ALSO
 AUTHORS
 -------
 * Matthias Stecher <matthiasstecher--@--gmx.de>
-* Dennis Camera <cdist--@--dtnr.ch>
+* Dennis Camera <skonfig--@--dtnr.ch>
 
 
 COPYING

--- a/type/__apt_backports/manifest
+++ b/type/__apt_backports/manifest
@@ -3,20 +3,20 @@
 # 2020 Matthias Stecher (matthiasstecher at gmx.de)
 # 2022-2023 Dennis Camera (skonfig at dtnr.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Enables/disables backports repository. Utilises __apt_source for it.

--- a/type/__apt_backports/manifest
+++ b/type/__apt_backports/manifest
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 #
 # 2020 Matthias Stecher (matthiasstecher at gmx.de)
-# 2022-2023 Dennis Camera (skonfig at dtnr.ch)
+# 2022-2023 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__apt_backports/manifest
+++ b/type/__apt_backports/manifest
@@ -18,9 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
+
 # Enables/disables backports repository. Utilises __apt_source for it.
-#
 
 distro_codename() {
     # prefer os_release because lsb_release(1) may not be available on all installations,

--- a/type/__apt_default_release/manifest
+++ b/type/__apt_default_release/manifest
@@ -3,20 +3,20 @@
 # 2014 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2017 Matthijs Kooijman (matthijs at stdin.nl)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 

--- a/type/__apt_key/explorer/state
+++ b/type/__apt_key/explorer/state
@@ -17,8 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Get the current state of the apt key.
+# Get the current state of the APT key.
 #
 
 if [ -f "$__object/parameter/keyid" ]; then

--- a/type/__apt_key/explorer/state
+++ b/type/__apt_key/explorer/state
@@ -2,20 +2,20 @@
 #
 # 2011-2014 Steven Armstrong (steven-cdist at armstrong.cc)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Get the current state of the apt key.

--- a/type/__apt_key/gencode-remote
+++ b/type/__apt_key/gencode-remote
@@ -2,20 +2,20 @@
 #
 # 2011-2014 Steven Armstrong (steven-cdist at armstrong.cc)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 if [ -f "$__object/parameter/keyid" ]; then

--- a/type/__apt_key/man.rst
+++ b/type/__apt_key/man.rst
@@ -93,8 +93,8 @@ EXAMPLES
 AUTHORS
 -------
 * Steven Armstrong <steven-cdist--@--armstrong.cc>
-* Ander Punnar <ander-at-kvlt-dot-ee>
-* Evilham <contact~~@~~evilham.com>
+* Ander Punnar <ander--@--kvlt.ee>
+* Evilham <contact--@--evilham.com>
 
 
 COPYING

--- a/type/__apt_key/manifest
+++ b/type/__apt_key/manifest
@@ -1,4 +1,23 @@
 #!/bin/sh -e
+#
+# 2019 Ander Punnar (ander at kvlt.ee)
+# 2021 Evil Ham (ungleich at evilham.com)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
 
 __package gnupg
 

--- a/type/__apt_key_uri/explorer/state
+++ b/type/__apt_key_uri/explorer/state
@@ -2,20 +2,20 @@
 #
 # 2011-2014 Steven Armstrong (steven-cdist at armstrong.cc)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Get the current state of the apt key.

--- a/type/__apt_key_uri/explorer/state
+++ b/type/__apt_key_uri/explorer/state
@@ -17,8 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Get the current state of the apt key.
+# Get the current state of the APT key.
 #
 
 if [ -f "$__object/parameter/name" ]; then

--- a/type/__apt_key_uri/gencode-remote
+++ b/type/__apt_key_uri/gencode-remote
@@ -2,20 +2,20 @@
 #
 # 2011-2014 Steven Armstrong (steven-cdist at armstrong.cc)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 if [ -f "$__object/parameter/name" ]; then

--- a/type/__apt_key_uri/manifest
+++ b/type/__apt_key_uri/manifest
@@ -2,20 +2,20 @@
 #
 # 2013-2014 Steven Armstrong (steven-cdist at armstrong.cc)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 __package curl

--- a/type/__apt_mark/explorer/apt_version
+++ b/type/__apt_mark/explorer/apt_version
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2016 Ander Punnar (cdist at kvlt.ee)
+# 2016 Ander Punnar (ander at kvlt.ee)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__apt_mark/explorer/apt_version
+++ b/type/__apt_mark/explorer/apt_version
@@ -17,6 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints "1" if the installed version of APT is at least 0.8.14.2,
+# "0" otherwise.
+#
 
 apt_version_is=$(dpkg-query --show --showformat '${Version}' apt)
 

--- a/type/__apt_mark/explorer/apt_version
+++ b/type/__apt_mark/explorer/apt_version
@@ -2,20 +2,20 @@
 #
 # 2016 Ander Punnar (cdist at kvlt.ee)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 apt_version_is=$(dpkg-query --show --showformat '${Version}' apt)

--- a/type/__apt_mark/explorer/package_installed
+++ b/type/__apt_mark/explorer/package_installed
@@ -17,6 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints "0" if the package specified by --name is already installed,
+# "1" otherwise.
+#
 
 if [ -f "$__object/parameter/name" ]; then
     name="$(cat "$__object/parameter/name")"

--- a/type/__apt_mark/explorer/package_installed
+++ b/type/__apt_mark/explorer/package_installed
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2016 Ander Punnar (cdist at kvlt.ee)
+# 2016 Ander Punnar (ander at kvlt.ee)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__apt_mark/explorer/package_installed
+++ b/type/__apt_mark/explorer/package_installed
@@ -2,20 +2,20 @@
 #
 # 2016 Ander Punnar (cdist at kvlt.ee)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 if [ -f "$__object/parameter/name" ]; then

--- a/type/__apt_mark/explorer/state
+++ b/type/__apt_mark/explorer/state
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints "hold" if the package specified by --name is held, "unhold" otherwise.
+#
 
 if [ -f "$__object/parameter/name" ]; then
     name="$(cat "$__object/parameter/name")"

--- a/type/__apt_mark/explorer/state
+++ b/type/__apt_mark/explorer/state
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2016 Ander Punnar (cdist at kvlt.ee)
+# 2016 Ander Punnar (ander at kvlt.ee)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__apt_mark/explorer/state
+++ b/type/__apt_mark/explorer/state
@@ -2,20 +2,20 @@
 #
 # 2016 Ander Punnar (cdist at kvlt.ee)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 if [ -f "$__object/parameter/name" ]; then

--- a/type/__apt_mark/gencode-remote
+++ b/type/__apt_mark/gencode-remote
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2016 Ander Punnar (cdist at kvlt.ee)
+# 2016 Ander Punnar (ander at kvlt.ee)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__apt_mark/gencode-remote
+++ b/type/__apt_mark/gencode-remote
@@ -2,20 +2,20 @@
 #
 # 2016 Ander Punnar (cdist at kvlt.ee)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 if [ -f "$__object/parameter/name" ]; then

--- a/type/__apt_mark/man.rst
+++ b/type/__apt_mark/man.rst
@@ -36,7 +36,7 @@ EXAMPLES
 
 AUTHORS
 -------
-* Ander Punnar <cdist--@--kvlt.ee>
+* Ander Punnar <ander--@--kvlt.ee>
 
 
 COPYING

--- a/type/__apt_norecommends/man.rst
+++ b/type/__apt_norecommends/man.rst
@@ -22,7 +22,7 @@ EXAMPLES
 AUTHORS
 -------
 * Steven Armstrong <steven-cdist--@--armstrong.cc>
-* Dennis Camera <dennis.camera--@--ssrq-sds-fds.ch>
+* Dennis Camera <dennis.camera--@--riiengineering.ch>
 
 
 COPYING

--- a/type/__apt_norecommends/manifest
+++ b/type/__apt_norecommends/manifest
@@ -3,20 +3,20 @@
 # 2014 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 

--- a/type/__apt_norecommends/manifest
+++ b/type/__apt_norecommends/manifest
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 #
 # 2014 Steven Armstrong (steven-cdist at armstrong.cc)
-# 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2020 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__apt_ppa/explorer/state
+++ b/type/__apt_ppa/explorer/state
@@ -2,20 +2,20 @@
 #
 # 2011 Steven Armstrong (steven-cdist at armstrong.cc)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Get the current state of the ppa.

--- a/type/__apt_ppa/explorer/state
+++ b/type/__apt_ppa/explorer/state
@@ -17,8 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Get the current state of the ppa.
+# Get the current state of the PPA.
 #
 
 name="$__object_id"

--- a/type/__apt_ppa/gencode-remote
+++ b/type/__apt_ppa/gencode-remote
@@ -2,20 +2,20 @@
 #
 # 2011 Steven Armstrong (steven-cdist at armstrong.cc)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 name="$__object_id"

--- a/type/__apt_ppa/manifest
+++ b/type/__apt_ppa/manifest
@@ -2,20 +2,20 @@
 #
 # 2011-2016 Steven Armstrong (steven-cdist at armstrong.cc)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 __package software-properties-common

--- a/type/__apt_source/gencode-remote
+++ b/type/__apt_source/gencode-remote
@@ -2,20 +2,20 @@
 #
 # 2018 Steven Armstrong (steven-cdist at armstrong.cc)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 

--- a/type/__apt_source/gencode-remote
+++ b/type/__apt_source/gencode-remote
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
 
 name="$__object_id"
 destination="/etc/apt/sources.list.d/${name}.list"

--- a/type/__apt_source/manifest
+++ b/type/__apt_source/manifest
@@ -2,20 +2,20 @@
 #
 # 2011-2018 Steven Armstrong (steven-cdist at armstrong.cc)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 name="$__object_id"

--- a/type/__apt_unattended_upgrades/man.rst
+++ b/type/__apt_unattended_upgrades/man.rst
@@ -55,7 +55,7 @@ EXAMPLES
 
 AUTHORS
 -------
-* Ander Punnar <ander-at-kvlt-dot-ee>
+* Ander Punnar <ander--@--kvlt.ee>
 
 
 COPYING

--- a/type/__apt_unattended_upgrades/manifest
+++ b/type/__apt_unattended_upgrades/manifest
@@ -1,21 +1,21 @@
 #!/bin/sh -e
 #
-# 2020 Ander Punnar (ander-at-kvlt-dot-ee)
+# 2020 Ander Punnar (ander at kvlt.ee)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 __package unattended-upgrades

--- a/type/__apt_update_index/explorer/state
+++ b/type/__apt_update_index/explorer/state
@@ -1,6 +1,24 @@
 #!/bin/sh -e
-
-# This file is part of cdist. See documentation for more information.
+#
+# 2021 Ander Punnar (ander at kvlt.ee)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
+# Prints whether the APT cache is outdated.
+#
 
 maxage="$( cat "$__object/parameter/maxage" )"
 

--- a/type/__apt_update_index/gencode-remote
+++ b/type/__apt_update_index/gencode-remote
@@ -2,20 +2,20 @@
 #
 # 2011 Steven Armstrong (steven-cdist at armstrong.cc)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 

--- a/type/__block/explorer/block
+++ b/type/__block/explorer/block
@@ -18,7 +18,9 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-
+# Prints the current contents of the block.
+# Nothing, if it does not exist (or is empty, obviously).
+#
 
 file="$(cat "$__object/parameter/file" 2>/dev/null || echo "/$__object_id")"
 

--- a/type/__block/explorer/block
+++ b/type/__block/explorer/block
@@ -3,20 +3,20 @@
 # 2013 Steven Armstrong (steven-cdist armstrong.cc)
 # 2014 Nico Schottelius (nico-cdist at schottelius.org)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 

--- a/type/__block/gencode-remote
+++ b/type/__block/gencode-remote
@@ -2,20 +2,20 @@
 #
 # 2013 Steven Armstrong (steven-cdist at armstrong.cc)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 # quote function from http://www.etalabs.net/sh_tricks.html

--- a/type/__block/manifest
+++ b/type/__block/manifest
@@ -2,20 +2,20 @@
 #
 # 2013-2014 Steven Armstrong (steven-cdist at armstrong.cc)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 prefix=$(cat "$__object/parameter/prefix" 2>/dev/null || echo "#cdist:__block/$__object_id")

--- a/type/__cdistmarker/gencode-remote
+++ b/type/__cdistmarker/gencode-remote
@@ -1,21 +1,21 @@
 #!/bin/sh -e
 #
-# Copyright (C) 2011 Daniel Maher (phrawzty+cdist at gmail.com)
+# 2011 Daniel Maher (phrawzty+cdist at gmail.com)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 # The marker file is established in the docs, but it isn't obligatory.

--- a/type/__check_messages/gencode-remote
+++ b/type/__check_messages/gencode-remote
@@ -1,21 +1,21 @@
 #!/bin/sh -e
 #
-# 2019 Ander Punnar (ander-at-kvlt-dot-ee)
+# 2019 Ander Punnar (ander at kvlt.ee)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 if grep -Eq \

--- a/type/__check_messages/man.rst
+++ b/type/__check_messages/man.rst
@@ -41,7 +41,7 @@ EXAMPLES
 
 AUTHORS
 -------
-* Ander Punnar <ander-at-kvlt-dot-ee>
+* Ander Punnar <ander--@--kvlt.ee>
 
 
 COPYING

--- a/type/__clean_path/explorer/find
+++ b/type/__clean_path/explorer/find
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2024 Ander Punnar (ander-at-kvlt-dot-ee)
+# 2024 Ander Punnar (ander at kvlt.ee)
 # 2024 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.

--- a/type/__clean_path/explorer/find
+++ b/type/__clean_path/explorer/find
@@ -17,6 +17,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
 
 if [ -f "$__object/parameter/path" ]
 then

--- a/type/__clean_path/explorer/find
+++ b/type/__clean_path/explorer/find
@@ -18,6 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints all files found which should be removed.
+#
 
 if [ -f "$__object/parameter/path" ]
 then

--- a/type/__clean_path/gencode-remote
+++ b/type/__clean_path/gencode-remote
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2024 Ander Punnar (ander-at-kvlt-dot-ee)
+# 2024 Ander Punnar (ander at kvlt.ee)
 # 2024 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.

--- a/type/__clean_path/man.rst
+++ b/type/__clean_path/man.rst
@@ -104,8 +104,8 @@ EXAMPLES
 
 AUTHORS
 -------
-* Ander Punnar <ander-at-kvlt-dot-ee>
-* Dennis Camera <dennis.camera-@-riiengineering.ch>
+* Ander Punnar <ander--@--kvlt.ee>
+* Dennis Camera <dennis.camera--@--riiengineering.ch>
 
 
 COPYING

--- a/type/__cron/explorer/cron-allowed
+++ b/type/__cron/explorer/cron-allowed
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2022 Dennis Camera (skonfig at dtnr.ch)
+# 2022 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__cron/explorer/cron-allowed
+++ b/type/__cron/explorer/cron-allowed
@@ -1,21 +1,21 @@
 #!/bin/sh -e
 #
-# 2022 Dennis Camera (cdist at dtnr.ch)
+# 2022 Dennis Camera (skonfig at dtnr.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 # Checks if --user is allowed to use cron.
 #

--- a/type/__cron/explorer/entry
+++ b/type/__cron/explorer/entry
@@ -1,21 +1,21 @@
 #!/bin/sh -e
 #
-# 2022 Dennis Camera (cdist at dtnr.ch)
+# 2022 Dennis Camera (skonfig at dtnr.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 # Prints the line matching $__object_name in --user’s current crontab.
 #

--- a/type/__cron/explorer/entry
+++ b/type/__cron/explorer/entry
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2022 Dennis Camera (skonfig at dtnr.ch)
+# 2022 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__cron/files/commands.sh
+++ b/type/__cron/files/commands.sh
@@ -1,6 +1,6 @@
 # NOTE: this file needs to be sourced and the $user variable needs to be defined
 #
-# 2022 Dennis Camera (skonfig at dtnr.ch)
+# 2022 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__cron/files/commands.sh
+++ b/type/__cron/files/commands.sh
@@ -1,4 +1,23 @@
 # NOTE: this file needs to be sourced and the $user variable needs to be defined
+#
+# 2022 Dennis Camera (skonfig at dtnr.ch)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
+
 : "${user:?}"
 
 prepare_cmds() { :; }

--- a/type/__cron/files/functions.sh
+++ b/type/__cron/files/functions.sh
@@ -1,3 +1,23 @@
+# NOTE: this file needs to be sourced.
+#
+# 2022 Dennis Camera (skonfig at dtnr.ch)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
+
 NL=$(printf '\n '); NL=${NL% }
 
 quote() { printf '%s\n' "$*" | sed "s/'/'\\\\''/g;1s/^/'/;\$s/\$/'/"; }

--- a/type/__cron/files/functions.sh
+++ b/type/__cron/files/functions.sh
@@ -1,6 +1,6 @@
 # NOTE: this file needs to be sourced.
 #
-# 2022 Dennis Camera (skonfig at dtnr.ch)
+# 2022 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__cron/files/lock.sh
+++ b/type/__cron/files/lock.sh
@@ -1,22 +1,22 @@
 #!/bin/sh -e
 #
-# 2020,2022 Dennis Camera (cdist at dtnr.ch)
+# 2020,2022 Dennis Camera (skonfig at dtnr.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 # It was originally written for __package_opkg’s pkg_status explorer.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 : "${__object:?}" "${__object_id:?}"  # assert __object and __object_id is set

--- a/type/__cron/files/lock.sh
+++ b/type/__cron/files/lock.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2020,2022 Dennis Camera (skonfig at dtnr.ch)
+# 2020,2022 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 # It was originally written for __package_opkg’s pkg_status explorer.

--- a/type/__cron/gencode-remote
+++ b/type/__cron/gencode-remote
@@ -3,7 +3,7 @@
 # 2011 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2013 Nico Schottelius (nico-cdist at schottelius.org)
 # 2017 Daniel Heule (hda at sfs.biz)
-# 2022 Dennis Camera (skonfig at dtnr.ch)
+# 2022 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__cron/gencode-remote
+++ b/type/__cron/gencode-remote
@@ -3,22 +3,22 @@
 # 2011 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2013 Nico Schottelius (nico-cdist at schottelius.org)
 # 2017 Daniel Heule (hda at sfs.biz)
-# 2022 Dennis Camera (cdist at dtnr.ch)
+# 2022 Dennis Camera (skonfig at dtnr.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 . "${__type:?}/files/functions.sh"

--- a/type/__cron/man.rst
+++ b/type/__cron/man.rst
@@ -98,7 +98,7 @@ SEE ALSO
 AUTHORS
 -------
 * Steven Armstrong <steven-cdist--@--armstrong.cc>
-* Dennis Camera <cdist--@--dtnr.ch>
+* Dennis Camera <skonfig--@--dtnr.ch>
 
 
 COPYING

--- a/type/__cron/man.rst
+++ b/type/__cron/man.rst
@@ -98,7 +98,7 @@ SEE ALSO
 AUTHORS
 -------
 * Steven Armstrong <steven-cdist--@--armstrong.cc>
-* Dennis Camera <skonfig--@--dtnr.ch>
+* Dennis Camera <dennis.camera--@--riiengineering.ch>
 
 
 COPYING

--- a/type/__cron_env/explorer/state
+++ b/type/__cron_env/explorer/state
@@ -1,21 +1,21 @@
 #!/bin/sh -e
 #
-# 2022 Dennis Camera (cdist at dtnr.ch)
+# 2022 Dennis Camera (skonfig at dtnr.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 # Returns the current state of the cron variable.
 #

--- a/type/__cron_env/explorer/state
+++ b/type/__cron_env/explorer/state
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2022 Dennis Camera (skonfig at dtnr.ch)
+# 2022 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__cron_env/gencode-remote
+++ b/type/__cron_env/gencode-remote
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2022 Dennis Camera (skonfig at dtnr.ch)
+# 2022 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__cron_env/gencode-remote
+++ b/type/__cron_env/gencode-remote
@@ -1,21 +1,21 @@
 #!/bin/sh -e
 #
-# 2022 Dennis Camera (cdist at dtnr.ch)
+# 2022 Dennis Camera (skonfig at dtnr.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 . "${__type:?}/files/functions.sh"

--- a/type/__cron_env/man.rst
+++ b/type/__cron_env/man.rst
@@ -69,7 +69,7 @@ SEE ALSO
 
 AUTHORS
 -------
-* Dennis Camera <skonfig--@--dtnr.ch>
+* Dennis Camera <dennis.camera--@--riiengineering.ch>
 
 
 COPYING

--- a/type/__cron_env/man.rst
+++ b/type/__cron_env/man.rst
@@ -69,7 +69,7 @@ SEE ALSO
 
 AUTHORS
 -------
-* Dennis Camera <cdist--@--dtnr.ch>
+* Dennis Camera <skonfig--@--dtnr.ch>
 
 
 COPYING

--- a/type/__debconf_set_selections/explorer/state
+++ b/type/__debconf_set_selections/explorer/state
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2021 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2021 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__debconf_set_selections/explorer/state
+++ b/type/__debconf_set_selections/explorer/state
@@ -2,20 +2,20 @@
 #
 # 2021 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 # Determine current debconf selections' state.
 # Prints one of:

--- a/type/__debconf_set_selections/gencode-remote
+++ b/type/__debconf_set_selections/gencode-remote
@@ -3,20 +3,20 @@
 # 2011-2014 Nico Schottelius (nico-cdist at schottelius.org)
 # 2021 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 if test -f "${__object:?}/parameter/line"

--- a/type/__debconf_set_selections/gencode-remote
+++ b/type/__debconf_set_selections/gencode-remote
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 #
 # 2011-2014 Nico Schottelius (nico-cdist at schottelius.org)
-# 2021 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2021 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__debconf_set_selections/man.rst
+++ b/type/__debconf_set_selections/man.rst
@@ -68,7 +68,7 @@ SEE ALSO
 AUTHORS
 -------
 * Nico Schottelius <nico-cdist--@--schottelius.org>
-* Dennis Camera <dennis.camera--@--ssrq-sds-fds.ch>
+* Dennis Camera <dennis.camera--@--riiengineering.ch>
 
 
 COPYING

--- a/type/__debconf_set_selections/manifest
+++ b/type/__debconf_set_selections/manifest
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2021 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2021 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__debconf_set_selections/manifest
+++ b/type/__debconf_set_selections/manifest
@@ -2,20 +2,20 @@
 #
 # 2021 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 __package_apt debconf

--- a/type/__directory/explorer/stat
+++ b/type/__directory/explorer/stat
@@ -3,20 +3,20 @@
 # 2013 Steven Armstrong (steven-cdist armstrong.cc)
 # 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 destination="/$__object_id"

--- a/type/__directory/explorer/stat
+++ b/type/__directory/explorer/stat
@@ -18,6 +18,14 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints stat information on the destination directory.
+#
+# Output is in the following format:
+# type: {regular file/directory/symbolic link/block special file/character special file/socket/fifo/...}
+# owner: {uid} {user name}
+# group: {gid} {group name}
+# mode: {numeric mode 4 digits} {mode string}
+#
 
 destination="/$__object_id"
 

--- a/type/__directory/explorer/stat
+++ b/type/__directory/explorer/stat
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 # 2013 Steven Armstrong (steven-cdist armstrong.cc)
-# 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2020 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__directory/explorer/type
+++ b/type/__directory/explorer/type
@@ -2,20 +2,20 @@
 #
 # 2013 Steven Armstrong (steven-cdist armstrong.cc)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 destination="/$__object_id"

--- a/type/__directory/explorer/type
+++ b/type/__directory/explorer/type
@@ -17,6 +17,10 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints the type of the destination.
+#
+# One of: directory, file, symlink, none, unknown.
+#
 
 destination="/$__object_id"
 

--- a/type/__directory/gencode-remote
+++ b/type/__directory/gencode-remote
@@ -5,20 +5,20 @@
 # 2014 Daniel Heule (hda at sfs.biz)
 # 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 destination="/$__object_id"

--- a/type/__directory/gencode-remote
+++ b/type/__directory/gencode-remote
@@ -3,7 +3,7 @@
 # 2011-2013 Nico Schottelius (nico-cdist at schottelius.org)
 # 2013 Steven Armstrong (steven-cdist armstrong.cc)
 # 2014 Daniel Heule (hda at sfs.biz)
-# 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2020 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__download/explorer/state
+++ b/type/__download/explorer/state
@@ -22,6 +22,7 @@
 #   "present" if the file exists (and the --sum matches)
 #   "mismatch" if the file exists (and the --sum does not match)
 #   "absent" if the file does not exist
+#
 
 if test -f "${__object:?}/parameter/destination"
 then

--- a/type/__download/explorer/state
+++ b/type/__download/explorer/state
@@ -19,9 +19,14 @@
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 # Prints the current state of the destionation file on the target.
-#   "present" if the file exists (and the --sum matches)
-#   "mismatch" if the file exists (and the --sum does not match)
-#   "absent" if the file does not exist
+#
+# Output is one of:
+#   present
+#     the file exists (and the --sum matches)
+#   mismatch
+#     the file exists (and the --sum does not match)
+#   absent
+#     if the file does not exist
 #
 
 if test -f "${__object:?}/parameter/destination"

--- a/type/__download/files/common.sh
+++ b/type/__download/files/common.sh
@@ -1,7 +1,7 @@
 # -*- mode: sh; indent-tabs-mode: t -*-
 # shellcheck shell=sh
 #
-# 2023 Dennis Camera (dennis.camera at riiengineering.ch
+# 2023 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__download/man.rst
+++ b/type/__download/man.rst
@@ -86,8 +86,8 @@ EXAMPLES
 
 AUTHORS
 -------
-* Ander Punnar <ander-at-kvlt-dot-ee>
-* Dennis Camera <dennis.camera at riiengineering.ch>
+* Ander Punnar <ander--@--kvlt.ee>
+* Dennis Camera <dennis.camera--@--riiengineering.ch>
 
 
 COPYING

--- a/type/__dpkg_architecture/explorer/architecture
+++ b/type/__dpkg_architecture/explorer/architecture
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints the main architecture dpkg is configured to install packages for.
+#
 
 # Get the main architecture of this machine
 

--- a/type/__dpkg_architecture/explorer/architecture
+++ b/type/__dpkg_architecture/explorer/architecture
@@ -1,22 +1,21 @@
 #!/bin/sh -e
-# __dpkg_architecture/explorer/architecture
 #
-# 2020 Matthias Stecher <matthiasstecher at gmx.de>
+# 2020 Matthias Stecher (matthiasstecher at gmx.de)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 # Get the main architecture of this machine

--- a/type/__dpkg_architecture/explorer/foreign-architectures
+++ b/type/__dpkg_architecture/explorer/foreign-architectures
@@ -17,6 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints a newline-separated list of extra architectures dpkg is configured to
+# allow packages to be installed for.
+#
 
 # Print all additional architectures
 

--- a/type/__dpkg_architecture/explorer/foreign-architectures
+++ b/type/__dpkg_architecture/explorer/foreign-architectures
@@ -1,22 +1,21 @@
 #!/bin/sh -e
-# __dpkg_architecture/explorer/foreign-architectures
 #
-# 2020 Matthias Stecher <matthiasstecher at gmx.de>
+# 2020 Matthias Stecher (matthiasstecher at gmx.de)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 # Print all additional architectures

--- a/type/__dpkg_architecture/gencode-remote
+++ b/type/__dpkg_architecture/gencode-remote
@@ -1,22 +1,22 @@
 #!/bin/sh -e
 # __dpkg_architecture/gencode-remote
 #
-# 2020 Matthias Stecher <matthiasstecher at gmx.de>
+# 2020 Matthias Stecher (matthiasstecher at gmx.de)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 

--- a/type/__dpkg_architecture/man.rst
+++ b/type/__dpkg_architecture/man.rst
@@ -86,7 +86,7 @@ Useful commands:
 
 AUTHORS
 -------
-* Matthias Stecher <matthiasstecher at gmx.de>
+* Matthias Stecher <matthiasstecher--@--gmx.de>
 
 
 COPYING

--- a/type/__file/files/functions.sh
+++ b/type/__file/files/functions.sh
@@ -1,5 +1,23 @@
 # -*- mode: sh; indent-tabs-mode: t -*-
 # shellcheck shell=sh
+#
+# 2023 Dennis Camera (dennis.camera at riiengineering.ch)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
 
 shquot() {
 	sed -e "s/'/'\\\\''/g" -e "1s/^/'/" -e "\$s/\$/'/" <<-EOF

--- a/type/__git/explorer/group
+++ b/type/__git/explorer/group
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 #
 # 2013 contradict (contradict at gmail.com)
-# 2021 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2021 Dennis Camera (dennis.camera at riiengineering.ch)
 # 2021 Ander Punnar (ander at kvlt.ee)
 #
 # This file is part of skonfig-base.

--- a/type/__git/explorer/group
+++ b/type/__git/explorer/group
@@ -1,4 +1,26 @@
 #!/bin/sh -e
+#
+# 2013 contradict (contradict at gmail.com)
+# 2021 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2021 Ander Punnar (ander at kvlt.ee)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
+# Prints the current group of the Git repository directory.
+#
 
 destination="/${__object_id:?}/.git"
 
@@ -14,7 +36,7 @@ then
 	then
 		printf '%u\n' "${group_gid}"
 	else
-		if command -v getent > /dev/null
+		if command -v getent >/dev/null
 		then
 			getent group "${group_gid}" | cut -d : -f 1
 		else

--- a/type/__git/explorer/owner
+++ b/type/__git/explorer/owner
@@ -1,4 +1,25 @@
 #!/bin/sh -e
+#
+# 2013 contradict (contradict at gmail.com)
+# 2021 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
+# Prints the current owner of the Git repository directory.
+#
 
 destination="/${__object_id:?}/.git"
 

--- a/type/__git/explorer/owner
+++ b/type/__git/explorer/owner
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 #
 # 2013 contradict (contradict at gmail.com)
-# 2021 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2021 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__git/explorer/state
+++ b/type/__git/explorer/state
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
 # Check whether repository exists
 #
 

--- a/type/__git/explorer/state
+++ b/type/__git/explorer/state
@@ -2,20 +2,20 @@
 #
 # 2012 Nico Schottelius (nico-cdist at schottelius.org)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Check whether repository exists

--- a/type/__git/gencode-remote
+++ b/type/__git/gencode-remote
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
 
 state_is=$(cat "$__object/explorer/state")
 owner_is=$(cat "$__object/explorer/owner")

--- a/type/__git/gencode-remote
+++ b/type/__git/gencode-remote
@@ -2,20 +2,20 @@
 #
 # 2012 Nico Schottelius (nico-cdist at schottelius.org)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 

--- a/type/__git/manifest
+++ b/type/__git/manifest
@@ -2,20 +2,20 @@
 #
 # 2012 Nico Schottelius (nico-cdist at schottelius.org)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Ensure git is present

--- a/type/__git/manifest
+++ b/type/__git/manifest
@@ -17,9 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Ensure git is present
-#
 
 __package git --state present
 

--- a/type/__group/explorer/group
+++ b/type/__group/explorer/group
@@ -3,20 +3,20 @@
 # 2011-2015 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2019 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Get an existing groups group entry.

--- a/type/__group/explorer/group
+++ b/type/__group/explorer/group
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 # 2011-2015 Steven Armstrong (steven-cdist at armstrong.cc)
-# 2019 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2019 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__group/explorer/group
+++ b/type/__group/explorer/group
@@ -18,8 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Get an existing groups group entry.
+# Get an existing group's group entry.
 #
 
 not_supported() {

--- a/type/__group/explorer/gshadow
+++ b/type/__group/explorer/gshadow
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 # 2011-2015 Steven Armstrong (steven-cdist at armstrong.cc)
-# 2019 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2019 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__group/explorer/gshadow
+++ b/type/__group/explorer/gshadow
@@ -18,8 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Get an existing groups gshadow entry.
+# Get an existing group's gshadow entry.
 #
 
 name=$__object_id

--- a/type/__group/explorer/gshadow
+++ b/type/__group/explorer/gshadow
@@ -3,20 +3,20 @@
 # 2011-2015 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2019 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Get an existing groups gshadow entry.

--- a/type/__group/gencode-remote
+++ b/type/__group/gencode-remote
@@ -18,9 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Manage groups.
-#
 
 name="$__object_id"
 os="$(cat "$__global/explorer/os")"

--- a/type/__group/gencode-remote
+++ b/type/__group/gencode-remote
@@ -3,20 +3,20 @@
 # 2011-2015 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2011 Nico Schottelius (nico-cdist at schottelius.org)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Manage groups.

--- a/type/__hostname/explorer/has_hostnamectl
+++ b/type/__hostname/explorer/has_hostnamectl
@@ -17,8 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Check whether system has hostnamectl
+# Check whether system has systemd's hostnamectl(1) installed.
 #
 
 command -v hostnamectl 2>/dev/null || true

--- a/type/__hostname/explorer/has_hostnamectl
+++ b/type/__hostname/explorer/has_hostnamectl
@@ -2,20 +2,20 @@
 #
 # 2014 Nico Schottelius (nico-cdist at schottelius.org)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Check whether system has hostnamectl

--- a/type/__hostname/explorer/max_len
+++ b/type/__hostname/explorer/max_len
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2019 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2019 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__hostname/explorer/max_len
+++ b/type/__hostname/explorer/max_len
@@ -1,4 +1,24 @@
 #!/bin/sh -e
+#
+# 2019 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
+# Prints the maximum length of a host name if defined on the system.
+#
 
 command -v getconf >/dev/null || exit 0
 

--- a/type/__hostname/gencode-remote
+++ b/type/__hostname/gencode-remote
@@ -2,7 +2,7 @@
 #
 # 2014-2017 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2014 Nico Schottelius (nico-cdist at schottelius.org)
-# 2019 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2019 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__hostname/gencode-remote
+++ b/type/__hostname/gencode-remote
@@ -4,20 +4,20 @@
 # 2014 Nico Schottelius (nico-cdist at schottelius.org)
 # 2019 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 os=$(cat "${__global:?}/explorer/os")

--- a/type/__hostname/man.rst
+++ b/type/__hostname/man.rst
@@ -42,7 +42,7 @@ EXAMPLES
 AUTHORS
 -------
 * Steven Armstrong <steven-cdist--@--armstrong.cc>
-* Dennis Camera <dennis.camera--@--ssrq-sds-fds.ch>
+* Dennis Camera <dennis.camera--@--riiengineering.ch>
 
 
 COPYING

--- a/type/__hostname/manifest
+++ b/type/__hostname/manifest
@@ -2,7 +2,7 @@
 #
 # 2012 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2014 Nico Schottelius (nico-cdist at schottelius.org)
-# 2019 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2019 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__hostname/manifest
+++ b/type/__hostname/manifest
@@ -4,20 +4,20 @@
 # 2014 Nico Schottelius (nico-cdist at schottelius.org)
 # 2019 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 set_hostname_systemd() {

--- a/type/__hosts/man.rst
+++ b/type/__hosts/man.rst
@@ -51,7 +51,7 @@ SEE ALSO
 
 AUTHORS
 -------
-* Dmitry Bogatov <KAction@gnu.org>
+* Dmitry Bogatov <KAction--@--gnu.org>
 * Dennis Camera <dennis.camera--@--ssrq-sds-fds.ch>
 
 

--- a/type/__hosts/man.rst
+++ b/type/__hosts/man.rst
@@ -52,7 +52,7 @@ SEE ALSO
 AUTHORS
 -------
 * Dmitry Bogatov <KAction--@--gnu.org>
-* Dennis Camera <dennis.camera--@--ssrq-sds-fds.ch>
+* Dennis Camera <dennis.camera--@--riiengineering.ch>
 
 
 COPYING

--- a/type/__hosts/manifest
+++ b/type/__hosts/manifest
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 #
 # 2015 Bogatov Dmitry (KAction at gnu.org)
-# 2019 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2019 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__hosts/manifest
+++ b/type/__hosts/manifest
@@ -1,22 +1,22 @@
 #!/bin/sh -e
 #
-# Copyright (C) 2015  Bogatov Dmitry <KAction@gnu.org>
+# 2015 Bogatov Dmitry (KAction at gnu.org)
 # 2019 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 set -e

--- a/type/__hwclock/explorer/adjtime_mode
+++ b/type/__hwclock/explorer/adjtime_mode
@@ -2,20 +2,20 @@
 #
 # 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 # Prints the clock mode read from the /etc/adjtime file, if present.
 #

--- a/type/__hwclock/explorer/adjtime_mode
+++ b/type/__hwclock/explorer/adjtime_mode
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2020 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__hwclock/explorer/timedatectl_localrtc
+++ b/type/__hwclock/explorer/timedatectl_localrtc
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2020 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__hwclock/explorer/timedatectl_localrtc
+++ b/type/__hwclock/explorer/timedatectl_localrtc
@@ -2,20 +2,20 @@
 #
 # 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 # Prints the LocalRTC property using timedatectl on systemd-based systems.
 #

--- a/type/__hwclock/gencode-remote
+++ b/type/__hwclock/gencode-remote
@@ -1,21 +1,21 @@
 #!/bin/sh -e
 #
-# 2020 Dennis Camera (dennis.camera@ssrq-sds-fds.ch)
+# 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 mode=$(cat "${__object:?}/parameter/mode")

--- a/type/__hwclock/gencode-remote
+++ b/type/__hwclock/gencode-remote
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2020 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__hwclock/man.rst
+++ b/type/__hwclock/man.rst
@@ -42,7 +42,7 @@ SEE ALSO
 
 AUTHORS
 -------
-* Dennis Camera <dennis.camera--@--ssrq-sds-fds.ch>
+* Dennis Camera <dennis.camera--@--riiengineering.ch>
 
 
 COPYING

--- a/type/__hwclock/manifest
+++ b/type/__hwclock/manifest
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2020 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__hwclock/manifest
+++ b/type/__hwclock/manifest
@@ -1,21 +1,21 @@
 #!/bin/sh -e
 #
-# 2020 Dennis Camera (dennis.camera@ssrq-sds-fds.ch)
+# 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 # TODO: Consider supporting BADYEAR

--- a/type/__key_value/explorer/state
+++ b/type/__key_value/explorer/state
@@ -1,22 +1,22 @@
 #!/bin/sh
 #
 # 2011 Steven Armstrong (steven-cdist at armstrong.cc)
-# 2014 Daniel Heule     (hda at sfs.biz)
+# 2014 Daniel Heule (hda at sfs.biz)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 key="$(cat "$__object/parameter/key" 2>/dev/null \

--- a/type/__key_value/explorer/state
+++ b/type/__key_value/explorer/state
@@ -18,6 +18,20 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints the current state of the key-value.
+#
+# Possible output values:
+#   present
+#     the key exists and is assigned the correct value.
+#   absent
+#     the key was not found in the file.
+#   wrongvalue
+#     the key exists but the value is different.
+#   nosuchfile
+#     the --file does not exist.
+#   wrongformat
+#     there is white-space around --delimiter but --exact_delimiter was used.
+#
 
 key="$(cat "$__object/parameter/key" 2>/dev/null \
    || echo "$__object_id")"

--- a/type/__key_value/files/remote_script.sh
+++ b/type/__key_value/files/remote_script.sh
@@ -1,4 +1,24 @@
 #!/bin/sh
+#
+# 2014 Daniel Heule (hda at sfs.biz)
+# 2018 Darko Poljak (darko.poljak at gmail.com)
+# 2020,2023 Dennis Camera (dennis.camera at riiengineering.ch)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
 
 key="$(cat "$__object/parameter/key" 2>/dev/null \
    || echo "$__object_id")"

--- a/type/__key_value/gencode-remote
+++ b/type/__key_value/gencode-remote
@@ -2,22 +2,22 @@
 #
 # 2011 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2012-2014 Nico Schottelius (nico-cdist at schottelius.org)
-# 2014 Daniel Heule     (hda at sfs.biz)
+# 2014 Daniel Heule (hda at sfs.biz)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 

--- a/type/__key_value/manifest
+++ b/type/__key_value/manifest
@@ -3,20 +3,20 @@
 # 2011 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2012 Nico Schottelius (nico-cdist at schottelius.org)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 state_should="$(cat "$__object/parameter/state")"

--- a/type/__line/explorer/state
+++ b/type/__line/explorer/state
@@ -3,20 +3,20 @@
 # 2018 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 if [ -f "$__object/parameter/file" ]; then

--- a/type/__line/explorer/state
+++ b/type/__line/explorer/state
@@ -18,6 +18,18 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints the current state of the line in the destination file.
+#
+# The output of this explorer is one of these values:
+#   present
+#     A line equal to --line is present in the file and located at an acceptable position.
+#   matching
+#     A line matching --regex is present, but it differs from --line.
+#   wrongposition
+#     A line matching --regex or --line is found in the file, but at the wrong position.
+#   absent
+#     No line matching --regex or --line was found in the file.
+#
 
 if [ -f "$__object/parameter/file" ]; then
    file=$(cat "$__object/parameter/file")

--- a/type/__line/explorer/state
+++ b/type/__line/explorer/state
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 #
 # 2018 Steven Armstrong (steven-cdist at armstrong.cc)
-# 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2020 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__line/gencode-remote
+++ b/type/__line/gencode-remote
@@ -3,20 +3,20 @@
 # 2018 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 if [ -f "$__object/parameter/before" ] && [ -f "$__object/parameter/after" ]; then

--- a/type/__line/gencode-remote
+++ b/type/__line/gencode-remote
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 #
 # 2018 Steven Armstrong (steven-cdist at armstrong.cc)
-# 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2020 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__link/explorer/state
+++ b/type/__link/explorer/state
@@ -3,20 +3,20 @@
 # 2012-2014 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2023 Dennis Camera (dennis.camera at riiengineering.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 destination="/${__object_id:?}"

--- a/type/__link/explorer/state
+++ b/type/__link/explorer/state
@@ -18,6 +18,18 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints the current state of the destination file.
+#
+# One of:
+#   present
+#     the destination exists and links to the correct source.
+#   sourcemissing
+#     the specified source does not exist (only for hard links).
+#   wrongsource
+#     the destination exists, but it links to a source different from the one specified.
+#   absent
+#     the destination does not exist.
+#
 
 destination="/${__object_id:?}"
 type=$(cat "${__object:?}/parameter/type")

--- a/type/__link/explorer/type
+++ b/type/__link/explorer/type
@@ -18,8 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Mostly a wrapper for ln
+# Print the current state of the destination file.
 #
 
 destination="/$__object_id"

--- a/type/__link/explorer/type
+++ b/type/__link/explorer/type
@@ -1,22 +1,22 @@
 #!/bin/sh
 #
 # 2013 Steven Armstrong (steven-cdist armstrong.cc)
-# 2023 Dennis Camera (dennis.camera at riiengineering.ch
+# 2023 Dennis Camera (dennis.camera at riiengineering.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Mostly a wrapper for ln

--- a/type/__link/gencode-remote
+++ b/type/__link/gencode-remote
@@ -3,20 +3,20 @@
 # 2011-2012 Nico Schottelius (nico-cdist at schottelius.org)
 # 2013-2014 Steven Armstrong (steven-cdist at armstrong.cc)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 destination="/$__object_id"

--- a/type/__locale_system/manifest
+++ b/type/__locale_system/manifest
@@ -3,7 +3,7 @@
 # 2012-2016 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2016 Carlos Ortigoza (carlos.ortigoza at ungleich.ch)
 # 2016 Nico Schottelius (nico.schottelius at ungleich.ch)
-# 2020,2022,2023 Dennis Camera (dennis.camera at riiengineering.ch
+# 2020,2022-2023 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__locale_system/manifest
+++ b/type/__locale_system/manifest
@@ -20,8 +20,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-# Configure system-wide locale by modifying i18n file.
-#
 
 version_ge() {
 	# usage: version_ge version_is min_version_expected

--- a/type/__localedef/explorer/state
+++ b/type/__localedef/explorer/state
@@ -2,20 +2,20 @@
 #
 # 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 # This explorer determines if the locale is defined on the target system.
 # Will print nothing on error.

--- a/type/__localedef/explorer/state
+++ b/type/__localedef/explorer/state
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2020 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__localedef/files/lib/glibc.sh
+++ b/type/__localedef/files/lib/glibc.sh
@@ -1,4 +1,22 @@
 # -*- mode: sh; indent-tabs-mode: t -*-
+#
+# 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
 
 gnu_normalize_codeset() {
 	echo "$*" | tr -cd '[:alnum:]' | tr '[:upper:]' '[:lower:]'

--- a/type/__localedef/files/lib/glibc.sh
+++ b/type/__localedef/files/lib/glibc.sh
@@ -1,6 +1,6 @@
 # -*- mode: sh; indent-tabs-mode: t -*-
 #
-# 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2020 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__localedef/files/lib/locale.sh
+++ b/type/__localedef/files/lib/locale.sh
@@ -1,4 +1,22 @@
 # -*- mode: sh; indent-tabs-mode:t -*-
+#
+# 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
 
 parse_locale() {
 	# This function will split locales into their parts. Locale strings are

--- a/type/__localedef/files/lib/locale.sh
+++ b/type/__localedef/files/lib/locale.sh
@@ -1,6 +1,6 @@
 # -*- mode: sh; indent-tabs-mode:t -*-
 #
-# 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2020 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__localedef/gencode-remote
+++ b/type/__localedef/gencode-remote
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 #
 # 2013-2019 Nico Schottelius (nico-cdist at schottelius.org)
-# 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2020 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__localedef/gencode-remote
+++ b/type/__localedef/gencode-remote
@@ -18,8 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-# Manage system locales using localedef(1).
-#
 
 # shellcheck source=cdist/conf/type/__localedef/files/lib/locale.sh
 . "${__type:?}/files/lib/locale.sh"

--- a/type/__localedef/gencode-remote
+++ b/type/__localedef/gencode-remote
@@ -3,20 +3,20 @@
 # 2013-2019 Nico Schottelius (nico-cdist at schottelius.org)
 # 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 # Manage system locales using localedef(1).
 #

--- a/type/__localedef/man.rst
+++ b/type/__localedef/man.rst
@@ -49,7 +49,7 @@ SEE ALSO
 
 AUTHORS
 -------
-* Dennis Camera <dennis.camera--@--ssrq-sds-fds.ch>
+* Dennis Camera <dennis.camera--@--riiengineering.ch>
 * Nico Schottelius <nico-cdist--@--schottelius.org>
 
 

--- a/type/__localedef/manifest
+++ b/type/__localedef/manifest
@@ -4,20 +4,20 @@
 # 2015 David Hürlimann (david at ungleich.ch)
 # 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 # Install required packages.
 #

--- a/type/__localedef/manifest
+++ b/type/__localedef/manifest
@@ -2,7 +2,7 @@
 #
 # 2013-2019 Nico Schottelius (nico-cdist at schottelius.org)
 # 2015 David Hürlimann (david at ungleich.ch)
-# 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2020 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__localedef/manifest
+++ b/type/__localedef/manifest
@@ -19,8 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+
 # Install required packages.
-#
 
 case $(cat "${__global:?}/explorer/os")
 in

--- a/type/__motd/gencode-remote
+++ b/type/__motd/gencode-remote
@@ -2,20 +2,20 @@
 #
 # 2013 Nico Schottelius (nico-cdist at schottelius.org)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 

--- a/type/__motd/gencode-remote
+++ b/type/__motd/gencode-remote
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
 
 os=$(cat "$__global/explorer/os")
 

--- a/type/__motd/manifest
+++ b/type/__motd/manifest
@@ -2,20 +2,20 @@
 #
 # 2011 Nico Schottelius (nico-cdist at schottelius.org)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 

--- a/type/__motd/manifest
+++ b/type/__motd/manifest
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
 
 # Select motd source
 if [ -f "$__object/parameter/source" ]; then

--- a/type/__mount/explorer/mounted
+++ b/type/__mount/explorer/mounted
@@ -2,20 +2,20 @@
 #
 # 2014 Steven Armstrong (steven-cdist at armstrong.cc)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 path="$(cat "$__object/parameter/path" 2>/dev/null || echo "/$__object_id")"

--- a/type/__mount/explorer/mounted
+++ b/type/__mount/explorer/mounted
@@ -17,6 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints "yes" if the mount point specified by --path is currently mounted,
+# "no" otherwise.
+#
 
 path="$(cat "$__object/parameter/path" 2>/dev/null || echo "/$__object_id")"
 

--- a/type/__mount/gencode-remote
+++ b/type/__mount/gencode-remote
@@ -2,20 +2,20 @@
 #
 # 2014 Steven Armstrong (steven-cdist at armstrong.cc)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 path="$(cat "$__object/parameter/path" 2>/dev/null || echo "/$__object_id")"

--- a/type/__mount/manifest
+++ b/type/__mount/manifest
@@ -2,20 +2,20 @@
 #
 # 2014 Steven Armstrong (steven-cdist at armstrong.cc)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 path="$(cat "$__object/parameter/path" 2>/dev/null || echo "/$__object_id")"

--- a/type/__package/explorer/pkgng_exists
+++ b/type/__package/explorer/pkgng_exists
@@ -2,20 +2,20 @@
 #
 # 2014 Jake Guffey (jake.guffey at eprotex.com)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Retrieve the status of a package - parsed dpkg output

--- a/type/__package/explorer/pkgng_exists
+++ b/type/__package/explorer/pkgng_exists
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
 # Retrieve the status of a package - parsed dpkg output
 #
 

--- a/type/__package/manifest
+++ b/type/__package/manifest
@@ -3,20 +3,20 @@
 # 2011-2013 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2019 Nico Schottelius (nico-cdist at schottelius.org)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # __package is an abstract type which dispatches to the lower level

--- a/type/__package/manifest
+++ b/type/__package/manifest
@@ -18,11 +18,10 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
+
 # __package is an abstract type which dispatches to the lower level
 # __package_$type types which do the actual interaction with the packaging
 # system.
-#
 
 type="$__object/parameter/type"
 if [ -f "$type" ]; then

--- a/type/__package_apk/explorer/state
+++ b/type/__package_apk/explorer/state
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
 # Retrieve the status of a package - parsed apk output
 #
 

--- a/type/__package_apk/explorer/state
+++ b/type/__package_apk/explorer/state
@@ -2,20 +2,20 @@
 #
 # 2019 Nico Schottelius (nico-cdist at schottelius.org)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Retrieve the status of a package - parsed apk output

--- a/type/__package_apk/gencode-remote
+++ b/type/__package_apk/gencode-remote
@@ -2,20 +2,20 @@
 #
 # 2019 Nico Schottelius (nico-cdist at schottelius.org)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Manage packages on Debian and co.

--- a/type/__package_apk/gencode-remote
+++ b/type/__package_apk/gencode-remote
@@ -17,9 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Manage packages on Debian and co.
-#
 
 if [ -f "$__object/parameter/name" ]; then
    name="$(cat "$__object/parameter/name")"

--- a/type/__package_apt/explorer/state
+++ b/type/__package_apt/explorer/state
@@ -1,22 +1,22 @@
 #!/bin/sh -e
 #
 # 2011-2012 Nico Schottelius (nico-cdist at schottelius.org)
-# 2021-2022 Dennis Camera (cdist at dtnr.ch)
+# 2021-2022 Dennis Camera (skonfig at dtnr.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Retrieve the status of a package - parsed dpkg output

--- a/type/__package_apt/explorer/state
+++ b/type/__package_apt/explorer/state
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 #
 # 2011-2012 Nico Schottelius (nico-cdist at schottelius.org)
-# 2021-2022 Dennis Camera (skonfig at dtnr.ch)
+# 2021-2022 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__package_apt/explorer/state
+++ b/type/__package_apt/explorer/state
@@ -18,8 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Retrieve the status of a package - parsed dpkg output
+# Print the current status of a package.
 #
 
 breify() {

--- a/type/__package_apt/gencode-remote
+++ b/type/__package_apt/gencode-remote
@@ -18,9 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Manage packages on Debian and co.
-#
 
 if [ -f "$__object/parameter/name" ]; then
    name="$(cat "$__object/parameter/name")"

--- a/type/__package_apt/gencode-remote
+++ b/type/__package_apt/gencode-remote
@@ -3,20 +3,20 @@
 # 2011-2013 Nico Schottelius (nico-cdist at schottelius.org)
 # 2021-2023 Dennis Camera (dennis.camera at riiengineering.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Manage packages on Debian and co.

--- a/type/__package_dpkg/explorer/pkg_state
+++ b/type/__package_dpkg/explorer/pkg_state
@@ -11,7 +11,7 @@
 #
 # skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/type/__package_dpkg/gencode-remote
+++ b/type/__package_dpkg/gencode-remote
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
+
 # This __package_dpkg type does not check whether a *.deb package is
 # allready installed. It just copies the *.deb package over to the
 # destination and installs it. We could use __package_apt to check

--- a/type/__package_dpkg/gencode-remote
+++ b/type/__package_dpkg/gencode-remote
@@ -1,22 +1,22 @@
 #!/bin/sh -e
 #
-# 2013 Tomas Pospisek (tpo_deb sourcepole.ch)
+# 2013 Tomas Pospisek (tpo_deb at sourcepole.ch)
 # 2018 Thomas Eckert (tom at it-eckert.de)
 #
-# This file is based on cdist's __file/gencode-local and part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # This __package_dpkg type does not check whether a *.deb package is

--- a/type/__package_dpkg/manifest
+++ b/type/__package_dpkg/manifest
@@ -1,19 +1,21 @@
 #!/bin/sh -e
 #
-# 2013 Tomas Pospisek (tpo_deb sourcepole.ch)
+# 2013 Tomas Pospisek (tpo_deb at sourcepole.ch)
 #
-# cdist is free software: you can redistribute it and/or modify
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # This __package_dpkg type does not check whether a *.deb package is

--- a/type/__package_dpkg/manifest
+++ b/type/__package_dpkg/manifest
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
+
 # This __package_dpkg type does not check whether a *.deb package is
 # allready installed. It just copies the *.deb package over to the
 # destination and installs it. We could use __package_apt to check

--- a/type/__package_emerge/explorer/pkg_version
+++ b/type/__package_emerge/explorer/pkg_version
@@ -17,8 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Retrieve the status of a package
+# Prints the currently installed version of a package.
 #
 
 if [ ! -x /usr/bin/equery ]; then

--- a/type/__package_emerge/explorer/pkg_version
+++ b/type/__package_emerge/explorer/pkg_version
@@ -2,20 +2,20 @@
 #
 # 2013 Thomas Oettli (otho at sfs.biz)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Retrieve the status of a package

--- a/type/__package_emerge/gencode-remote
+++ b/type/__package_emerge/gencode-remote
@@ -17,9 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Manage packages with Portage (mostly gentoo)
-#
 
 if [ -f "$__object/parameter/name" ]; then
    name="$__object/parameter/name"

--- a/type/__package_emerge/gencode-remote
+++ b/type/__package_emerge/gencode-remote
@@ -2,20 +2,20 @@
 #
 # 2013 Thomas Oettli (otho at sfs.biz)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Manage packages with Portage (mostly gentoo)

--- a/type/__package_emerge_dependencies/explorer/flaggie_installed
+++ b/type/__package_emerge_dependencies/explorer/flaggie_installed
@@ -1,4 +1,24 @@
 #!/bin/sh
+#
+# 2013 Daniel Heule (hda at sfs.biz)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
+# Prints "true" if flaggie is installed, "false" otherwise.
+#
 
 if [ -x /usr/bin/flaggie ]; then
     echo "true"

--- a/type/__package_emerge_dependencies/explorer/gentoolkit_installed
+++ b/type/__package_emerge_dependencies/explorer/gentoolkit_installed
@@ -1,4 +1,24 @@
 #!/bin/sh
+#
+# 2013 Daniel Heule (hda at sfs.biz)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
+# Prints "true" if gentoolkit is installed, "false" otherwise.
+#
 
 if [ -x /usr/bin/q ]; then
     echo "true"

--- a/type/__package_emerge_dependencies/gencode-remote
+++ b/type/__package_emerge_dependencies/gencode-remote
@@ -1,4 +1,23 @@
 #!/bin/sh -e
+#
+# 2013 Daniel Heule (hda at sfs.biz)
+# 2018 Takashi Yoshi (takashi at yoshi.email)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
 
 gentoolkit_installed="$(cat "$__object/explorer/gentoolkit_installed")"
 flaggie_installed="$(cat "$__object/explorer/flaggie_installed")"

--- a/type/__package_luarocks/explorer/pkg_status
+++ b/type/__package_luarocks/explorer/pkg_status
@@ -1,22 +1,21 @@
 #!/bin/sh
 #
-# 2012 SwellPath, Inc.
-# Christian G. Warden <cwarden@xerus.org>
+# 2012 Christian G. Warden (cwarden at xerus.org)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 # Retrieve the status of a rock
 #

--- a/type/__package_luarocks/gencode-remote
+++ b/type/__package_luarocks/gencode-remote
@@ -1,22 +1,21 @@
 #!/bin/sh -e
 #
-# 2012 SwellPath, Inc.
-# Christian G. Warden <cwarden@xerus.org>
+# 2012 Christian G. Warden (cwarden at xerus.org)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Manage LuaRocks packages

--- a/type/__package_luarocks/gencode-remote
+++ b/type/__package_luarocks/gencode-remote
@@ -17,9 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Manage LuaRocks packages
-#
 
 
 if [ -f "$__object/parameter/name" ]; then

--- a/type/__package_luarocks/man.rst
+++ b/type/__package_luarocks/man.rst
@@ -48,12 +48,12 @@ SEE ALSO
 
 AUTHORS
 -------
-* Christian G. Warden <cwarden@xerus.org>
+* Christian G. Warden <cwarden--@--xerus.org>
 
 
 COPYING
 -------
-Copyright \(C) 2012 SwellPath, Inc.
+Copyright \(C) 2012 Christian G. Warden.
 You can redistribute it and/or modify it under the terms of the GNU General
 Public License as published by the Free Software Foundation, either version 3 of
 the License, or (at your option) any later version.

--- a/type/__package_luarocks/manifest
+++ b/type/__package_luarocks/manifest
@@ -1,22 +1,21 @@
 #!/bin/sh -e
 #
-# 2012 SwellPath, Inc.
-# Christian G. Warden <cwarden@xerus.org>
+# 2012 Christian G. Warden (cwarden at xerus.org)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 __package luarocks --state installed

--- a/type/__package_opkg/explorer/pkg_status
+++ b/type/__package_opkg/explorer/pkg_status
@@ -2,7 +2,7 @@
 #
 # 2011 Nico Schottelius (nico-cdist at schottelius.org)
 # 2012 Giel van Schijndel (giel plus cdist at mortis dot eu)
-# 2020,2022 Dennis Camera (skonfig at dtnr.ch)
+# 2020,2022 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__package_opkg/explorer/pkg_status
+++ b/type/__package_opkg/explorer/pkg_status
@@ -19,8 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Retrieve the status of a package - parses opkg output
+# Retrieve the status of a package - parses opkg output.
 #
 
 : "${__object:?}"  # assert __object is set

--- a/type/__package_opkg/explorer/pkg_status
+++ b/type/__package_opkg/explorer/pkg_status
@@ -2,22 +2,22 @@
 #
 # 2011 Nico Schottelius (nico-cdist at schottelius.org)
 # 2012 Giel van Schijndel (giel plus cdist at mortis dot eu)
-# 2020,2022 Dennis Camera (cdist at dtnr.ch)
+# 2020,2022 Dennis Camera (skonfig at dtnr.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Retrieve the status of a package - parses opkg output

--- a/type/__package_opkg/gencode-remote
+++ b/type/__package_opkg/gencode-remote
@@ -2,7 +2,7 @@
 #
 # 2011,2013 Nico Schottelius (nico-cdist at schottelius.org)
 # 2012 Giel van Schijndel (giel plus cdist at mortis dot eu)
-# 2020,2022 Dennis Camera (skonfig at dtnr.ch)
+# 2020,2022 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__package_opkg/gencode-remote
+++ b/type/__package_opkg/gencode-remote
@@ -19,9 +19,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Manage packages on OpenWrt, optware, and co.
-#
 
 quote() { printf '%s\n' "$*" | sed "s/'/'\\\\''/g;1s/^/'/;\$s/\$/'/"; }
 

--- a/type/__package_opkg/gencode-remote
+++ b/type/__package_opkg/gencode-remote
@@ -2,22 +2,22 @@
 #
 # 2011,2013 Nico Schottelius (nico-cdist at schottelius.org)
 # 2012 Giel van Schijndel (giel plus cdist at mortis dot eu)
-# 2020,2022 Dennis Camera (cdist at dtnr.ch)
+# 2020,2022 Dennis Camera (skonfig at dtnr.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Manage packages on OpenWrt, optware, and co.

--- a/type/__package_pacman/explorer/pkg_version
+++ b/type/__package_pacman/explorer/pkg_version
@@ -2,20 +2,20 @@
 #
 # 2011-2012 Nico Schottelius (nico-cdist at schottelius.org)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Retrieve the status of a package - parsed pacman output

--- a/type/__package_pacman/explorer/pkg_version
+++ b/type/__package_pacman/explorer/pkg_version
@@ -17,8 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Retrieve the status of a package - parsed pacman output
+# Prints the currently installed version of the package.
 #
 
 if [ -f "$__object/parameter/name" ]; then

--- a/type/__package_pacman/gencode-remote
+++ b/type/__package_pacman/gencode-remote
@@ -17,9 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Manage packages with Pacman (mostly archlinux)
-#
 
 # Debug
 # exec >&2

--- a/type/__package_pacman/gencode-remote
+++ b/type/__package_pacman/gencode-remote
@@ -2,20 +2,20 @@
 #
 # 2011-2012 Nico Schottelius (nico-cdist at schottelius.org)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Manage packages with Pacman (mostly archlinux)

--- a/type/__package_pip/explorer/pip
+++ b/type/__package_pip/explorer/pip
@@ -18,6 +18,7 @@
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 # Prints a command that can be used to execute pip(1).
+#
 # If a pip binary exists, its path will be printed, a fallback to
 # {python} -m pip, otherwise.
 # In any case, the first word will be an absolute path.

--- a/type/__package_pip/explorer/state
+++ b/type/__package_pip/explorer/state
@@ -17,6 +17,14 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints the current state of the pip package.
+#
+# One of:
+#   present
+#     the package is currently installed.
+#   absent
+#     the package is not installed.
+#
 
 shebang_of() { sed -n -e '1s/^#! *//p' "$1"; }
 

--- a/type/__package_pkg_freebsd/explorer/pkg_version
+++ b/type/__package_pkg_freebsd/explorer/pkg_version
@@ -17,8 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Retrieve the status of a package - parsed dpkg output
+# Prints the version of the currently installed package.
 #
 
 if [ -f "$__object/parameter/name" ]; then

--- a/type/__package_pkg_freebsd/explorer/pkg_version
+++ b/type/__package_pkg_freebsd/explorer/pkg_version
@@ -2,20 +2,20 @@
 #
 # 2012 Jake Guffey (jake.guffey at eprotex.com)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Retrieve the status of a package - parsed dpkg output

--- a/type/__package_pkg_freebsd/gencode-remote
+++ b/type/__package_pkg_freebsd/gencode-remote
@@ -2,20 +2,20 @@
 #
 # 2012 Jake Guffey (jake.guffey at eprotex.com)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Manage packages with pkg on FreeBSD

--- a/type/__package_pkg_freebsd/gencode-remote
+++ b/type/__package_pkg_freebsd/gencode-remote
@@ -17,9 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Manage packages with pkg on FreeBSD
-#
 
 assert ()                 #  If condition false,
 {                         #+ exit from script with error message.

--- a/type/__package_pkg_openbsd/explorer/has_installurl
+++ b/type/__package_pkg_openbsd/explorer/has_installurl
@@ -1,21 +1,21 @@
 #!/bin/sh
 #
-# Copyright 2017, Philippe Gregoire <pg@pgregoire.xyz>
+# 2017 Philippe Gregoire (pg at pgregoire.xyz)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 #

--- a/type/__package_pkg_openbsd/explorer/has_installurl
+++ b/type/__package_pkg_openbsd/explorer/has_installurl
@@ -17,10 +17,10 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints "yes" if the installurl(5) file, as introduced in OpenBSD 6.1, exists,
+# "no" otherwise.
+#
 
-#
-# Retrieve the installurl(5), as introduced in OpenBSD 6.1
-#
 # As of 6.1, the file is supposed to contained a single line
 # with the URL used to install from during install or upgrade.
 #

--- a/type/__package_pkg_openbsd/explorer/pkg_state
+++ b/type/__package_pkg_openbsd/explorer/pkg_state
@@ -1,21 +1,21 @@
 #!/bin/sh
 #
-# Copyright 2018, Takashi Yoshi <takashi@yoshi.email>
+# 2018 Takashi Yoshi (takashi at yoshi.email)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Retrieve the status of a package - parsed pkg_info output

--- a/type/__package_pkg_openbsd/explorer/pkg_state
+++ b/type/__package_pkg_openbsd/explorer/pkg_state
@@ -17,8 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Retrieve the status of a package - parsed pkg_info output
+# Prints the currently installed version of a package.
 #
 
 if [ -f "${__object}/parameter/name" ]

--- a/type/__package_pkg_openbsd/gencode-remote
+++ b/type/__package_pkg_openbsd/gencode-remote
@@ -19,9 +19,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Manage packages with pkg on OpenBSD
-#
 
 os_version=$(cat "${__global}/explorer/os_version")
 machine=$(cat "${__global}/explorer/machine")

--- a/type/__package_pkg_openbsd/gencode-remote
+++ b/type/__package_pkg_openbsd/gencode-remote
@@ -2,22 +2,22 @@
 #
 # 2011 Andi Brönnimann (andi-cdist at v-net.ch)
 # 2012 Nico Schottelius (nico-cdist at schottelius.org)
-# 2018 Takashi Yoshi <takashi@yoshi.email>
+# 2018 Takashi Yoshi (takashi at yoshi.email)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Manage packages with pkg on OpenBSD

--- a/type/__package_pkgng_freebsd/explorer/pkg_bootstrapped
+++ b/type/__package_pkgng_freebsd/explorer/pkg_bootstrapped
@@ -1,4 +1,26 @@
 #!/bin/sh -e
-if pkg -N >/dev/null 2>&1; then
+#
+# 2020 Evilham (cvs at evilham.com)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
+# Prints "YES" if the pkgng package manager is bootstrapped.
+#
+
+if pkg -N >/dev/null 2>&1
+then
 	echo "YES"
 fi

--- a/type/__package_pkgng_freebsd/explorer/pkg_version
+++ b/type/__package_pkgng_freebsd/explorer/pkg_version
@@ -2,20 +2,20 @@
 #
 # 2014 Jake Guffey (jake.guffey at eprotex.com)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Retrieve the status of a package - parsed pkgng output

--- a/type/__package_pkgng_freebsd/explorer/pkg_version
+++ b/type/__package_pkgng_freebsd/explorer/pkg_version
@@ -17,8 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Retrieve the status of a package - parsed pkgng output
+# Retrieve the status of a package - parsed pkgng output.
 #
 
 if ! pkg -N >/dev/null 2>&1; then

--- a/type/__package_pkgng_freebsd/gencode-remote
+++ b/type/__package_pkgng_freebsd/gencode-remote
@@ -2,20 +2,20 @@
 #
 # 2014 Jake Guffey (jake.guffey at eprotex.com)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Manage packages with pkg on FreeBSD

--- a/type/__package_pkgng_freebsd/gencode-remote
+++ b/type/__package_pkgng_freebsd/gencode-remote
@@ -17,9 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Manage packages with pkg on FreeBSD
-#
 
 # Debug
 #exec >&2

--- a/type/__package_rubygem/explorer/pkg_status
+++ b/type/__package_rubygem/explorer/pkg_status
@@ -1,21 +1,21 @@
 #!/bin/sh
 #
-# 2011 Chase Allen James (nx-cdist@nu-ex.com)
+# 2011 Chase Allen James (nx-cdist at nu-ex.com)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 # Retrieve the status of a rubygem
 #

--- a/type/__package_rubygem/gencode-remote
+++ b/type/__package_rubygem/gencode-remote
@@ -1,21 +1,21 @@
 #!/bin/sh -e
 #
-# 2011 Chase Allen James <nx-cdist@nu-ex.com>
+# 2011 Chase Allen James (nx-cdist at nu-ex.com)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Manage Rubygem packages

--- a/type/__package_rubygem/gencode-remote
+++ b/type/__package_rubygem/gencode-remote
@@ -17,9 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Manage Rubygem packages
-#
 
 if [ -f "$__object/parameter/name" ]; then
     name="$(cat "$__object/parameter/name")"

--- a/type/__package_rubygem/man.rst
+++ b/type/__package_rubygem/man.rst
@@ -49,7 +49,7 @@ SEE ALSO
 
 AUTHORS
 -------
-* Chase Allen James <nx-cdist@nu-ex.com>
+* Chase Allen James <nx-cdist--@--nu-ex.com>
 
 
 COPYING

--- a/type/__package_yum/explorer/pkg_version
+++ b/type/__package_yum/explorer/pkg_version
@@ -17,8 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Retrieve the status of a package
+# Retrieve the status of a package.
 #
 
 if [ -f "$__object/parameter/name" ]; then

--- a/type/__package_yum/explorer/pkg_version
+++ b/type/__package_yum/explorer/pkg_version
@@ -2,20 +2,20 @@
 #
 # 2011-2012 Nico Schottelius (nico-cdist at schottelius.org)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Retrieve the status of a package

--- a/type/__package_yum/gencode-remote
+++ b/type/__package_yum/gencode-remote
@@ -2,20 +2,20 @@
 #
 # 2011-2014 Nico Schottelius (nico-cdist at schottelius.org)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Manage packages with yum (mostly Fedora)

--- a/type/__package_yum/gencode-remote
+++ b/type/__package_yum/gencode-remote
@@ -17,9 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Manage packages with yum (mostly Fedora)
-#
 
 if [ -f "$__object/parameter/name" ]; then
    name="$(cat "$__object/parameter/name")"

--- a/type/__package_zypper/explorer/pkg_version
+++ b/type/__package_zypper/explorer/pkg_version
@@ -3,20 +3,20 @@
 # 2011-2012 Nico Schottelius (nico-cdist at schottelius.org)
 # 2013 Daniel Heule (hda at sfs.biz)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Retrieve the status of a package of different types

--- a/type/__package_zypper/explorer/pkg_version
+++ b/type/__package_zypper/explorer/pkg_version
@@ -18,7 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
 # Retrieve the status of a package of different types
 #
 

--- a/type/__package_zypper/gencode-remote
+++ b/type/__package_zypper/gencode-remote
@@ -3,20 +3,20 @@
 # 2012 Nico Schottelius (nico-cdist at schottelius.org)
 # 2013 Daniel Heule (hda at sfs.biz)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Manage packages with Zypper (mostly suse)

--- a/type/__package_zypper/gencode-remote
+++ b/type/__package_zypper/gencode-remote
@@ -18,9 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Manage packages with Zypper (mostly suse)
-#
 
 # Debug
 # exec >&2

--- a/type/__pacman_conf/man.rst
+++ b/type/__pacman_conf/man.rst
@@ -73,7 +73,7 @@ SEE ALSO
 
 AUTHORS
 -------
-* Dominique Roux <dominique.roux4@gmail.com>
+* Dominique Roux <dominique.roux4--@--gmail.com>
 
 
 COPYING

--- a/type/__pacman_conf/manifest
+++ b/type/__pacman_conf/manifest
@@ -2,20 +2,20 @@
 #
 # 2015 Dominique Roux (dominique.roux4 at gmail.com)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 #get params

--- a/type/__pacman_conf_integrate/man.rst
+++ b/type/__pacman_conf_integrate/man.rst
@@ -40,7 +40,7 @@ SEE ALSO
 
 AUTHORS
 -------
-* Dominique Roux <dominique.roux4@gmail.com>
+* Dominique Roux <dominique.roux4--@--gmail.com>
 
 
 COPYING

--- a/type/__pacman_conf_integrate/manifest
+++ b/type/__pacman_conf_integrate/manifest
@@ -1,21 +1,21 @@
 #!/bin/sh -e
 #
-# 2015 Dominique Roux (dominique.roux4 at gmail.com
+# 2015 Dominique Roux (dominique.roux4 at gmail.com)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 state=$(cat "$__object/parameter/state" 2>/dev/null)

--- a/type/__pyvenv/gencode-remote
+++ b/type/__pyvenv/gencode-remote
@@ -18,7 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
 
 state_is="$(cat "$__object/explorer/state")"
 owner_is="$(cat "$__object/explorer/owner")"

--- a/type/__rsync/gencode-local
+++ b/type/__rsync/gencode-local
@@ -1,4 +1,23 @@
 #!/bin/sh -e
+#
+# 2021,2023 Ander Punnar (ander at kvlt.ee)
+# 2023-2024 Dennis Camera (dennis.camera at riiengineering.ch)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
 
 shquot() {
 sed -e "s/'/'\\\\''/g" -e "1s/^/'/" -e "\$s/\$/'/" <<EOF

--- a/type/__rsync/man.rst
+++ b/type/__rsync/man.rst
@@ -96,8 +96,8 @@ EXAMPLES
 
 AUTHORS
 -------
-* Ander Punnar <ander-at-kvlt-dot-ee>
-* Dennis Camera <dennis.camera-at-riiengineering.ch>
+* Ander Punnar <ander--@--kvlt.ee>
+* Dennis Camera <dennis.camera--@--riiengineering.ch>
 
 
 COPYING

--- a/type/__rsync/manifest
+++ b/type/__rsync/manifest
@@ -1,3 +1,21 @@
 #!/bin/sh -e
+#
+# 2015 Nico Schottelius (nico-cdist at schottelius.org)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
 
 __package rsync

--- a/type/__sed/explorer/file
+++ b/type/__sed/explorer/file
@@ -1,4 +1,25 @@
 #!/bin/sh -e
+#
+# 2021 Ander Punnar (ander at kvlt.ee)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
+# Print the contents of the desination file or raise an error if it does not
+# exist.
+#
 
 if [ -f "$__object/parameter/file" ]
 then

--- a/type/__sed/gencode-remote
+++ b/type/__sed/gencode-remote
@@ -1,4 +1,22 @@
 #!/bin/sh -e
+#
+# 2021-2022 Ander Punnar (ander at kvlt.ee)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
 
 if [ -f "$__object/parameter/file" ]
 then

--- a/type/__sed/man.rst
+++ b/type/__sed/man.rst
@@ -45,7 +45,7 @@ EXAMPLES
 
 AUTHORS
 -------
-* Ander Punnar <ander-at-kvlt-dot-ee>
+* Ander Punnar <ander--@--kvlt.ee>
 
 
 COPYING

--- a/type/__sensible_editor/explorer/group
+++ b/type/__sensible_editor/explorer/group
@@ -11,7 +11,7 @@
 #
 # skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/type/__sensible_editor/explorer/user_home
+++ b/type/__sensible_editor/explorer/user_home
@@ -11,7 +11,7 @@
 #
 # skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/type/__skonfigmarker/gencode-remote
+++ b/type/__skonfigmarker/gencode-remote
@@ -2,20 +2,20 @@
 #
 # 2023 Dennis Camera (dennis.camera at riiengineering.ch)
 #
-# This file is part of skonfig.
+# This file is part of skonfig-base.
 #
-# skonfig is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# skonfig is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with skonfig. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 shquot() {

--- a/type/__ssh_authorized_keys/explorer/file
+++ b/type/__ssh_authorized_keys/explorer/file
@@ -3,20 +3,20 @@
 # 2014 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2019 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 if [ -f "$__object/parameter/file" ]; then

--- a/type/__ssh_authorized_keys/explorer/file
+++ b/type/__ssh_authorized_keys/explorer/file
@@ -18,6 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints the path of the destination file chosen to be managed.
+#
 
 if [ -f "$__object/parameter/file" ]; then
 	cat "$__object/parameter/file"

--- a/type/__ssh_authorized_keys/explorer/file
+++ b/type/__ssh_authorized_keys/explorer/file
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 # 2014 Steven Armstrong (steven-cdist at armstrong.cc)
-# 2019 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2019 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__ssh_authorized_keys/explorer/group
+++ b/type/__ssh_authorized_keys/explorer/group
@@ -3,20 +3,20 @@
 # 2014 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2019 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 if [ -s "$__object/parameter/owner" ]

--- a/type/__ssh_authorized_keys/explorer/group
+++ b/type/__ssh_authorized_keys/explorer/group
@@ -18,6 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints the group(5) entry of --owner’s primary group.
+#
 
 if [ -s "$__object/parameter/owner" ]
 then

--- a/type/__ssh_authorized_keys/explorer/group
+++ b/type/__ssh_authorized_keys/explorer/group
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 # 2014 Steven Armstrong (steven-cdist at armstrong.cc)
-# 2019 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2019 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__ssh_authorized_keys/explorer/keys
+++ b/type/__ssh_authorized_keys/explorer/keys
@@ -1,4 +1,23 @@
 #!/bin/sh -e
+#
+# 2020 Ander Punnar (ander at kvlt.ee)
+# 2020 Darko Poljak (foss at ungleich.com)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
 
 # shellcheck disable=SC1090
 # shellcheck disable=SC1091

--- a/type/__ssh_authorized_keys/explorer/keys
+++ b/type/__ssh_authorized_keys/explorer/keys
@@ -18,6 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints the current contents of the --file chosen to be managed.
+#
 
 # shellcheck disable=SC1090
 # shellcheck disable=SC1091

--- a/type/__ssh_authorized_keys/manifest
+++ b/type/__ssh_authorized_keys/manifest
@@ -3,20 +3,20 @@
 # 2012-2014 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2014 Nico Schottelius (nico-cdist at schottelius.org)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 owner="$(cat "$__object/parameter/owner" 2>/dev/null || echo "$__object_id")"

--- a/type/__ssh_dot_ssh/explorer/group
+++ b/type/__ssh_dot_ssh/explorer/group
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 # 2014 Steven Armstrong (steven-cdist at armstrong.cc)
-# 2019 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2019 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__ssh_dot_ssh/explorer/group
+++ b/type/__ssh_dot_ssh/explorer/group
@@ -18,6 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints the group(5) entry of the owner’s primary group.
+#
 
 gid=$("$__type_explorer/passwd" | cut -d':' -f4)
 

--- a/type/__ssh_dot_ssh/explorer/group
+++ b/type/__ssh_dot_ssh/explorer/group
@@ -3,20 +3,20 @@
 # 2014 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2019 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 gid=$("$__type_explorer/passwd" | cut -d':' -f4)

--- a/type/__ssh_dot_ssh/explorer/passwd
+++ b/type/__ssh_dot_ssh/explorer/passwd
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints the passwd(5) entry of the user named after __object_id.
+#
 
 owner="$__object_id"
 

--- a/type/__ssh_dot_ssh/explorer/passwd
+++ b/type/__ssh_dot_ssh/explorer/passwd
@@ -2,7 +2,7 @@
 #
 # 2012 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2014 Nico Schottelius (nico-cdist at schottelius.org)
-# 2019 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2019 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__ssh_dot_ssh/explorer/passwd
+++ b/type/__ssh_dot_ssh/explorer/passwd
@@ -4,20 +4,20 @@
 # 2014 Nico Schottelius (nico-cdist at schottelius.org)
 # 2019 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 owner="$__object_id"

--- a/type/__ssh_dot_ssh/manifest
+++ b/type/__ssh_dot_ssh/manifest
@@ -18,8 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-# Hacked in Kalamata, Greece
-#
 
 owner="$__object_id"
 state="$(cat "$__object/parameter/state")"

--- a/type/__ssh_dot_ssh/manifest
+++ b/type/__ssh_dot_ssh/manifest
@@ -3,20 +3,20 @@
 # 2012-2014 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2014 Nico Schottelius (nico-cdist at schottelius.org)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 # Hacked in Kalamata, Greece
 #

--- a/type/__sshd_config/explorer/state
+++ b/type/__sshd_config/explorer/state
@@ -18,10 +18,14 @@
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 # Determines the current state of the config option.
+#
 # Possible output:
-#  - present: "should" option present in config file
-#  - default: the "should" option is the default -> don’t know if present
-#  - absent: no such option present in config file
+#   present
+#     "should" option present in config file
+#   default
+#     the "should" option is the default -> don’t know if present
+#   absent
+#     no such option present in config file
 #
 
 joinlines() { sed -n -e H -e "\${x;s/^\\n//;s/\\n/${1:?}/g;p;}"; }

--- a/type/__sshd_config/files/update_sshd_config.awk
+++ b/type/__sshd_config/files/update_sshd_config.awk
@@ -1,4 +1,22 @@
 # -*- mode: awk; indent-tabs-mode: t -*-
+#
+# 2020-2021 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
 
 function usage() {
 	print_err("Usage: awk -f update_sshd_config.awk -- -o set|unset [-m 'User git'] -l 'X11Forwarding no' /etc/ssh/sshd_config")

--- a/type/__sshd_config/files/update_sshd_config.awk
+++ b/type/__sshd_config/files/update_sshd_config.awk
@@ -1,6 +1,6 @@
 # -*- mode: awk; indent-tabs-mode: t -*-
 #
-# 2020-2021 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2020-2021 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__staged_file/gencode-local
+++ b/type/__staged_file/gencode-local
@@ -3,20 +3,20 @@
 # 2015 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2015 Nico Schottelius (nico-cdist at schottelius.org)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 #set -x

--- a/type/__staged_file/manifest
+++ b/type/__staged_file/manifest
@@ -2,20 +2,20 @@
 #
 # 2015 Steven Armstrong (steven-cdist at armstrong.cc)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 destination="$__object_id"

--- a/type/__start_on_boot/explorer/state
+++ b/type/__start_on_boot/explorer/state
@@ -3,20 +3,20 @@
 # 2012-2019 Nico Schottelius (nico-cdist at schottelius.org)
 # 2013 Daniel Heule (hda at sfs.biz)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Check whether the given name will be started on boot or not

--- a/type/__start_on_boot/explorer/state
+++ b/type/__start_on_boot/explorer/state
@@ -18,8 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Check whether the given name will be started on boot or not
+# Check whether the given name will be started on boot or not.
 #
 
 os=$("$__explorer/os")

--- a/type/__start_on_boot/gencode-remote
+++ b/type/__start_on_boot/gencode-remote
@@ -18,7 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
 
 state_should="$(cat "$__object/parameter/state")"
 state_is=$(cat "$__object/explorer/state")

--- a/type/__start_on_boot/gencode-remote
+++ b/type/__start_on_boot/gencode-remote
@@ -3,20 +3,20 @@
 # 2012-2013 Nico Schottelius (nico-cdist at schottelius.org)
 # 2016 Daniel Heule (hda at sfs.biz)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 

--- a/type/__start_on_boot/manifest
+++ b/type/__start_on_boot/manifest
@@ -1,4 +1,23 @@
 #!/bin/sh -e
+#
+# 2018 Kamila Součková (kamila at ksp.sk)
+# 2018 Jonas Weber (github at jonasw.de)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
 
 state_should="$(cat "$__object/parameter/state")"
 state_is=$(cat "$__object/explorer/state")

--- a/type/__svn/explorer/group
+++ b/type/__svn/explorer/group
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2021-2022 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2021-2022 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__svn/explorer/group
+++ b/type/__svn/explorer/group
@@ -2,20 +2,20 @@
 #
 # 2021-2022 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 # Prints the group of the current working copy root (if present).
 # The printed value will be

--- a/type/__svn/explorer/mode
+++ b/type/__svn/explorer/mode
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2021 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2021 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__svn/explorer/mode
+++ b/type/__svn/explorer/mode
@@ -2,20 +2,20 @@
 #
 # 2021 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 # Prints the mode of the current working copy root (if present).
 #

--- a/type/__svn/explorer/owner
+++ b/type/__svn/explorer/owner
@@ -2,20 +2,20 @@
 #
 # 2021-2022 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 # Prints the owner of the current working copy root (if present).
 # The printed value will be

--- a/type/__svn/explorer/owner
+++ b/type/__svn/explorer/owner
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2021-2022 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2021-2022 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__svn/explorer/state
+++ b/type/__svn/explorer/state
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2021 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2021 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__svn/explorer/state
+++ b/type/__svn/explorer/state
@@ -2,20 +2,20 @@
 #
 # 2021 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 # Check whether the working cops exists.
 #

--- a/type/__svn/gencode-remote
+++ b/type/__svn/gencode-remote
@@ -2,20 +2,20 @@
 #
 # 2021-2022 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 quote() { printf '%s\n' "$*" | sed "s/'/'\\\\''/g;1s/^/'/;\$s/\$/'/"; }

--- a/type/__svn/gencode-remote
+++ b/type/__svn/gencode-remote
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2021-2022 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2021-2022 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__svn/man.rst
+++ b/type/__svn/man.rst
@@ -64,7 +64,7 @@ SEE ALSO
 
 AUTHORS
 -------
-* Dennis Camera <dennis.camera--@--ssrq-sds-fds.ch>
+* Dennis Camera <dennis.camera--@--riiengineering.ch>
 
 
 COPYING

--- a/type/__svn/manifest
+++ b/type/__svn/manifest
@@ -2,20 +2,20 @@
 #
 # 2021-2022 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 

--- a/type/__svn/manifest
+++ b/type/__svn/manifest
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2021-2022 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2021-2022 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__sysctl/explorer/conf-path
+++ b/type/__sysctl/explorer/conf-path
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints the file path used by skonfig to store sysctl values.
+#
 
 if [ -d "/etc/sysctl.d" ]; then
     echo "/etc/sysctl.d/99-Z-sysctl-cdist.conf";

--- a/type/__sysctl/explorer/conf-path
+++ b/type/__sysctl/explorer/conf-path
@@ -2,20 +2,20 @@
 #
 # 2018 Darko Poljak (darko.poljak at gmail.com)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 if [ -d "/etc/sysctl.d" ]; then

--- a/type/__sysctl/explorer/value
+++ b/type/__sysctl/explorer/value
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints the current running value of the given sysctl option.
+#
 
 if test "$(uname -s)" = NetBSD
 then

--- a/type/__sysctl/explorer/value
+++ b/type/__sysctl/explorer/value
@@ -2,20 +2,20 @@
 #
 # 2014 Steven Armstrong (steven-cdist at armstrong.cc)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 if test "$(uname -s)" = NetBSD

--- a/type/__sysctl/gencode-remote
+++ b/type/__sysctl/gencode-remote
@@ -3,20 +3,20 @@
 # 2014 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2018 Takashi Yoshi (takashi at yoshi.email)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 value_should="$(cat "$__object/parameter/value")"

--- a/type/__sysctl/manifest
+++ b/type/__sysctl/manifest
@@ -4,20 +4,20 @@
 # 2018 Takashi Yoshi (takashi at yoshi.email)
 # 2019 Nico Schottelius (nico-cdist at schottelius.org)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 

--- a/type/__systemd_service/explorer/state
+++ b/type/__systemd_service/explorer/state
@@ -18,13 +18,16 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-
-# Check if the service is running or stopped.
+# Prints if the --name service is currently running.
 #
-# The explorer must check before if the service exist, because 'systemctl is-active'
-# will return "inactive" even if there is no service there:
-#   systemctl cat foo        # does not exist
-#   systemctl is-active foo  # is "inactive"
+# Outputs:
+#   "running"
+#     the service is currently running.
+#   "stopped"
+#     the service is currently not running.
+#   ""
+#     the service does not exist on the target.
+#
 
 
 # get name of the service
@@ -34,6 +37,10 @@ else
     name="$__object_id"
 fi
 
+# The explorer must check before if the service exist, because 'systemctl is-active'
+# will return "inactive" even if there is no service there:
+#   systemctl cat foo        # does not exist
+#   systemctl is-active foo  # is "inactive"
 
 # check if the service exist, else exit without output (also if systemd doesn't exist)
 # do not exit here with an error code, will be done in the gencode-remote script

--- a/type/__systemd_service/explorer/state
+++ b/type/__systemd_service/explorer/state
@@ -1,22 +1,22 @@
 #!/bin/sh -e
 # explorer/state
 #
-# 2020 Matthias Stecher <matthiasstecher at gmx.de>
+# 2020 Matthias Stecher (matthiasstecher at gmx.de)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 # Check if the service is running or stopped.

--- a/type/__systemd_service/gencode-remote
+++ b/type/__systemd_service/gencode-remote
@@ -1,22 +1,22 @@
 #!/bin/sh -e
 # gencode-remote
 #
-# 2020 Matthias Stecher <matthiasstecher at gmx.de>
+# 2020 Matthias Stecher (matthiasstecher at gmx.de)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 # Checks the given state of the service and set it to the given

--- a/type/__systemd_service/man.rst
+++ b/type/__systemd_service/man.rst
@@ -95,7 +95,7 @@ systemd or the service does not exist
 
 AUTHORS
 -------
-* Matthias Stecher <matthiasstecher at gmx.de>
+* Matthias Stecher <matthiasstecher--@--gmx.de>
 
 
 COPYING

--- a/type/__systemd_unit/explorer/enablement-state
+++ b/type/__systemd_unit/explorer/enablement-state
@@ -17,5 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints the current enablemene state of the unit named after __object_id.
+#
+# For possible output values cf. man systemctl(1).
+#
 
 systemctl is-enabled "${__object_id}" 2>/dev/null || true

--- a/type/__systemd_unit/explorer/enablement-state
+++ b/type/__systemd_unit/explorer/enablement-state
@@ -1,21 +1,21 @@
 #!/bin/sh
 #
-# 2017 Ľubomír Kučera <lubomir.kucera.jr at gmail.com>
+# 2017 Ľubomír Kučera (lubomir.kucera.jr at gmail.com)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 systemctl is-enabled "${__object_id}" 2>/dev/null || true

--- a/type/__systemd_unit/explorer/systemctl-present
+++ b/type/__systemd_unit/explorer/systemctl-present
@@ -17,5 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints "0" if the systemctl command is available, "1" otherwise.
+#
 
 command -v systemctl > /dev/null 2>&1 && echo 0 || echo 1

--- a/type/__systemd_unit/explorer/systemctl-present
+++ b/type/__systemd_unit/explorer/systemctl-present
@@ -1,21 +1,21 @@
 #!/bin/sh
 #
-# 2017 Ľubomír Kučera <lubomir.kucera.jr at gmail.com>
+# 2017 Ľubomír Kučera (lubomir.kucera.jr at gmail.com)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 command -v systemctl > /dev/null 2>&1 && echo 0 || echo 1

--- a/type/__systemd_unit/explorer/unit-status
+++ b/type/__systemd_unit/explorer/unit-status
@@ -17,5 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints the current ACTIVE state of the unit named after __object_id.
+#
+# For possible values cf. man systemctl(1), search for "Unit ACTIVE states".
+#
 
 systemctl is-active "${__object_id}" || true

--- a/type/__systemd_unit/explorer/unit-status
+++ b/type/__systemd_unit/explorer/unit-status
@@ -1,21 +1,21 @@
 #!/bin/sh
 #
-# 2017 Ľubomír Kučera <lubomir.kucera.jr at gmail.com>
+# 2017 Ľubomír Kučera (lubomir.kucera.jr at gmail.com)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 systemctl is-active "${__object_id}" || true

--- a/type/__systemd_unit/gencode-remote
+++ b/type/__systemd_unit/gencode-remote
@@ -1,21 +1,21 @@
 #!/bin/sh -e
 #
-# 2017 Ľubomír Kučera <lubomir.kucera.jr at gmail.com>
+# 2017 Ľubomír Kučera (lubomir.kucera.jr at gmail.com)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 name="${__object_id}"

--- a/type/__systemd_unit/man.rst
+++ b/type/__systemd_unit/man.rst
@@ -92,8 +92,8 @@ EXAMPLES
 
 AUTHORS
 -------
-* Ľubomír Kučera <lubomir.kucera.jr at gmail.com>
-* Ander Punnar <ander-at-kvlt-dot-ee>
+* Ľubomír Kučera <lubomir.kucera.jr--@--gmail.com>
+* Ander Punnar <ander--@--kvlt.ee>
 
 
 COPYING

--- a/type/__systemd_unit/manifest
+++ b/type/__systemd_unit/manifest
@@ -1,21 +1,21 @@
 #!/bin/sh -e
 #
-# 2017 Ľubomír Kučera <lubomir.kucera.jr at gmail.com>
+# 2017 Ľubomír Kučera (lubomir.kucera.jr at gmail.com)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 systemctl_present=$(cat "${__object}/explorer/systemctl-present")

--- a/type/__timezone/explorer/timezone_is
+++ b/type/__timezone/explorer/timezone_is
@@ -2,20 +2,20 @@
 #
 # 2017 Ander Punnar (cdist at kvlt.ee)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 [ -f /etc/timezone ] && cat /etc/timezone

--- a/type/__timezone/explorer/timezone_is
+++ b/type/__timezone/explorer/timezone_is
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints the contents of /etc/timezone.
+#
 
 [ -f /etc/timezone ] && cat /etc/timezone
 

--- a/type/__timezone/explorer/timezone_is
+++ b/type/__timezone/explorer/timezone_is
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2017 Ander Punnar (cdist at kvlt.ee)
+# 2017 Ander Punnar (ander at kvlt.ee)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__timezone/gencode-remote
+++ b/type/__timezone/gencode-remote
@@ -18,8 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# This type allows to configure the desired localtime timezone.
 
 timezone_is=$(cat "$__object/explorer/timezone_is")
 timezone_should=$(cat "$__object/parameter/tz")

--- a/type/__timezone/gencode-remote
+++ b/type/__timezone/gencode-remote
@@ -3,20 +3,20 @@
 # 2012 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2019 Nico Schottelius (nico-cdist at schottelius.org)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # This type allows to configure the desired localtime timezone.

--- a/type/__timezone/man.rst
+++ b/type/__timezone/man.rst
@@ -34,7 +34,7 @@ AUTHORS
 -------
 * Steven Armstrong <steven-cdist--@--armstrong.cc>
 * Nico Schottelius <nico-cdist--@--schottelius.org>
-* Ramon Salvadó <rsalvado--@--gnuine--dot--com>
+* Ramon Salvadó <rsalvado--@--gnuine.com>
 * Dennis Camera <dennis.camera--@--ssrq-sds-fds.ch>
 
 

--- a/type/__timezone/man.rst
+++ b/type/__timezone/man.rst
@@ -35,7 +35,7 @@ AUTHORS
 * Steven Armstrong <steven-cdist--@--armstrong.cc>
 * Nico Schottelius <nico-cdist--@--schottelius.org>
 * Ramon Salvadó <rsalvado--@--gnuine.com>
-* Dennis Camera <dennis.camera--@--ssrq-sds-fds.ch>
+* Dennis Camera <dennis.camera--@--riiengineering.ch>
 
 
 COPYING

--- a/type/__timezone/manifest
+++ b/type/__timezone/manifest
@@ -1,23 +1,23 @@
 #!/bin/sh -e
 #
-# 2011 Ramon Salvadó (rsalvado at gnuine dot com)
+# 2011 Ramon Salvadó (rsalvado at gnuine.com)
 # 2012-2015 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2012-2019 Nico Schottelius (nico-cdist at schottelius.org)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # This type allows to configure the desired localtime timezone.

--- a/type/__timezone/manifest
+++ b/type/__timezone/manifest
@@ -19,8 +19,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# This type allows to configure the desired localtime timezone.
 
 timezone=$(cat "$__object/parameter/tz")
 os=$(cat "$__global/explorer/os")

--- a/type/__uci/explorer/state
+++ b/type/__uci/explorer/state
@@ -1,21 +1,21 @@
 #!/bin/sh -e
 #
-# 2020,2022 Dennis Camera (cdist at dtnr.ch)
+# 2020,2022 Dennis Camera (skonfig at dtnr.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 # This explorer retrieves the current state of the configuration option
 # The output of this explorer is one of these values:

--- a/type/__uci/explorer/state
+++ b/type/__uci/explorer/state
@@ -30,6 +30,7 @@
 #   rearranged
 #     The configuration option is present (a list) and has the same values as
 #     the parameter --value, but in a different order.
+#
 
 # NOTE: older releases of OpenWrt do not include sbin in PATH but uci(1) is
 #       installed in /sbin.

--- a/type/__uci/explorer/state
+++ b/type/__uci/explorer/state
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2020,2022 Dennis Camera (skonfig at dtnr.ch)
+# 2020,2022 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__uci/files/functions.sh
+++ b/type/__uci/files/functions.sh
@@ -1,6 +1,6 @@
 # -*- mode: sh; indent-tabs-mode: t -*-
 #
-# 2020 Dennis Camera (skonfig at dtnr.ch)
+# 2020 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__uci/files/functions.sh
+++ b/type/__uci/files/functions.sh
@@ -1,4 +1,22 @@
 # -*- mode: sh; indent-tabs-mode: t -*-
+#
+# 2020 Dennis Camera (skonfig at dtnr.ch)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
 
 in_list() {
 	printf '%s\n' "$@" | { grep -qxF "$(read -r ndl; echo "${ndl}")"; }

--- a/type/__uci/files/uci_apply.sh
+++ b/type/__uci/files/uci_apply.sh
@@ -1,6 +1,6 @@
 # -*- mode: sh; indent-tabs-mode: t -*-
 #
-# 2020,2022 Dennis Camera (skonfig at dtnr.ch)
+# 2020,2022 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__uci/files/uci_apply.sh
+++ b/type/__uci/files/uci_apply.sh
@@ -1,3 +1,23 @@
+# -*- mode: sh; indent-tabs-mode: t -*-
+#
+# 2020,2022 Dennis Camera (skonfig at dtnr.ch)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
+
 # NOTE: older releases of OpenWrt do not include sbin in PATH but uci(1) is
 #       installed in /sbin.
 PATH=/bin:/sbin:/usr/bin:/usr/sbin

--- a/type/__uci/gencode-remote
+++ b/type/__uci/gencode-remote
@@ -1,21 +1,21 @@
 #!/bin/sh -e
 #
-# 2020,2022 Dennis Camera (cdist at dtnr.ch)
+# 2020,2022 Dennis Camera (skonfig at dtnr.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 # shellcheck source=type/__uci/files/functions.sh

--- a/type/__uci/gencode-remote
+++ b/type/__uci/gencode-remote
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2020,2022 Dennis Camera (skonfig at dtnr.ch)
+# 2020,2022 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__uci/man.rst
+++ b/type/__uci/man.rst
@@ -64,7 +64,7 @@ SEE ALSO
 
 AUTHORS
 -------
-* Dennis Camera <cdist--@--dtnr.ch>
+* Dennis Camera <skonfig--@--dtnr.ch>
 
 
 COPYING

--- a/type/__uci/man.rst
+++ b/type/__uci/man.rst
@@ -64,7 +64,7 @@ SEE ALSO
 
 AUTHORS
 -------
-* Dennis Camera <skonfig--@--dtnr.ch>
+* Dennis Camera <dennis.camera--@--riiengineering.ch>
 
 
 COPYING

--- a/type/__uci/manifest
+++ b/type/__uci/manifest
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2020,2022 Dennis Camera (skonfig at dtnr.ch)
+# 2020,2022 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__uci/manifest
+++ b/type/__uci/manifest
@@ -1,21 +1,21 @@
 #!/bin/sh -e
 #
-# 2020,2022 Dennis Camera (cdist at dtnr.ch)
+# 2020,2022 Dennis Camera (skonfig at dtnr.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 os=$(cat "${__global:?}/explorer/os")

--- a/type/__uci_section/explorer/match
+++ b/type/__uci_section/explorer/match
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2020 Dennis Camera (skonfig at dtnr.ch)
+# 2020 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__uci_section/explorer/match
+++ b/type/__uci_section/explorer/match
@@ -1,21 +1,21 @@
 #!/bin/sh -e
 #
-# 2020 Dennis Camera (cdist at dtnr.ch)
+# 2020 Dennis Camera (skonfig at dtnr.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 # This explorer determines the "prefix" of the --type section matching --match
 # if set, or __object_id otherwise.

--- a/type/__uci_section/explorer/match
+++ b/type/__uci_section/explorer/match
@@ -17,8 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-# This explorer determines the "prefix" of the --type section matching --match
-# if set, or __object_id otherwise.
+# Prints the "prefix" of the --type section matching --match if set,
+# or __object_id otherwise.
+#
 
 RS=$(printf '\036')
 NL=$(printf '\n '); NL=${NL% }

--- a/type/__uci_section/explorer/options
+++ b/type/__uci_section/explorer/options
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2020 Dennis Camera (skonfig at dtnr.ch)
+# 2020 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__uci_section/explorer/options
+++ b/type/__uci_section/explorer/options
@@ -1,21 +1,21 @@
 #!/bin/sh -e
 #
-# 2020 Dennis Camera (cdist at dtnr.ch)
+# 2020 Dennis Camera (skonfig at dtnr.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 # This explorer retrieves the current options of the configuration section.
 

--- a/type/__uci_section/explorer/options
+++ b/type/__uci_section/explorer/options
@@ -17,7 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-# This explorer retrieves the current options of the configuration section.
+# Prints the current options of the configuration section.
+#
 
 RS=$(printf '\036')
 

--- a/type/__uci_section/explorer/type
+++ b/type/__uci_section/explorer/type
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2020 Dennis Camera (skonfig at dtnr.ch)
+# 2020 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__uci_section/explorer/type
+++ b/type/__uci_section/explorer/type
@@ -1,21 +1,21 @@
 #!/bin/sh -e
 #
-# 2020 Dennis Camera (cdist at dtnr.ch)
+# 2020 Dennis Camera (skonfig at dtnr.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 # This explorer retrieves the current section type.
 

--- a/type/__uci_section/explorer/type
+++ b/type/__uci_section/explorer/type
@@ -17,7 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-# This explorer retrieves the current section type.
+# Prints the current section type.
+#
 
 section=$("${__type_explorer:?}/match")
 test -n "${section}" || exit 0

--- a/type/__uci_section/files/functions.sh
+++ b/type/__uci_section/files/functions.sh
@@ -1,6 +1,6 @@
 # -*- mode: sh; indent-tabs-mode: t -*-
 #
-# 2020 Dennis Camera (skonfig at dtnr.ch)
+# 2020 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__uci_section/files/functions.sh
+++ b/type/__uci_section/files/functions.sh
@@ -1,4 +1,22 @@
 # -*- mode: sh; indent-tabs-mode: t -*-
+#
+# 2020 Dennis Camera (skonfig at dtnr.ch)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
 
 NL=$(printf '\n '); NL=${NL% }
 

--- a/type/__uci_section/files/option_state.awk
+++ b/type/__uci_section/files/option_state.awk
@@ -1,4 +1,23 @@
 # -*- mode: awk; indent-tabs-mode:t -*-
+#
+# 2020 Dennis Camera (skonfig at dtnr.ch)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
+
 # Usage: awk -f option_state.awk option_type option_name
 # e.g. awk -f option_state.awk option title
 #      awk -f option_state.awk list entry

--- a/type/__uci_section/files/option_state.awk
+++ b/type/__uci_section/files/option_state.awk
@@ -1,6 +1,6 @@
 # -*- mode: awk; indent-tabs-mode:t -*-
 #
-# 2020 Dennis Camera (skonfig at dtnr.ch)
+# 2020 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__uci_section/gencode-remote
+++ b/type/__uci_section/gencode-remote
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2020 Dennis Camera (skonfig at dtnr.ch)
+# 2020 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__uci_section/gencode-remote
+++ b/type/__uci_section/gencode-remote
@@ -1,21 +1,21 @@
 #!/bin/sh -e
 #
-# 2020 Dennis Camera (cdist at dtnr.ch)
+# 2020 Dennis Camera (skonfig at dtnr.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 # shellcheck source=type/__uci_section/files/functions.sh

--- a/type/__uci_section/man.rst
+++ b/type/__uci_section/man.rst
@@ -99,7 +99,7 @@ SEE ALSO
 
 AUTHORS
 -------
-* Dennis Camera <skonfig--@--dtnr.ch>
+* Dennis Camera <dennis.camera--@--riiengineering.ch>
 
 
 COPYING

--- a/type/__uci_section/man.rst
+++ b/type/__uci_section/man.rst
@@ -99,7 +99,7 @@ SEE ALSO
 
 AUTHORS
 -------
-* Dennis Camera <cdist--@--dtnr.ch>
+* Dennis Camera <skonfig--@--dtnr.ch>
 
 
 COPYING

--- a/type/__uci_section/manifest
+++ b/type/__uci_section/manifest
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2020 Dennis Camera (skonfig at dtnr.ch)
+# 2020 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__uci_section/manifest
+++ b/type/__uci_section/manifest
@@ -1,21 +1,21 @@
 #!/bin/sh -e
 #
-# 2020 Dennis Camera (cdist at dtnr.ch)
+# 2020 Dennis Camera (skonfig at dtnr.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 # shellcheck source=type/__uci_section/files/functions.sh

--- a/type/__unpack/explorer/state
+++ b/type/__unpack/explorer/state
@@ -1,4 +1,25 @@
 #!/bin/sh -e
+#
+# 2020 Ander Punnar (ander at kvlt.ee)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
+# Checks if the checksum of the archive on the target matches the expected
+# value.
+#
 
 src="/$__object_id"
 

--- a/type/__unpack/gencode-remote
+++ b/type/__unpack/gencode-remote
@@ -1,4 +1,24 @@
 #!/bin/sh -e
+#
+# 2020 Ander Punnar (ander at kvlt.ee)
+# 2021,2023 Dennis Camera (dennis.camera at riiengineering.ch)
+# 2022 Travis Paul (tr at vispaul.me)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
 
 quote() { printf '%s\n' "$*" | sed "s/'/'\\\\''/g;1s/^/'/;\$s/\$/'/"; }
 

--- a/type/__unpack/man.rst
+++ b/type/__unpack/man.rst
@@ -78,7 +78,7 @@ EXAMPLES
 
 AUTHORS
 -------
-* Ander Punnar <ander-at-kvlt-dot-ee>
+* Ander Punnar <ander--@--kvlt.ee>
 
 
 COPYING

--- a/type/__unpack/manifest
+++ b/type/__unpack/manifest
@@ -1,4 +1,24 @@
 #!/bin/sh -e
+#
+# 2020 Ander Punnar (ander at kvlt.ee)
+# 2022 Travis Paul (tr at vispaul.me)
+# 2023 Dennis Camera (dennis.camera at riiengineering.ch)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
 
 os="$( cat "$__global/explorer/os" )"
 

--- a/type/__update_alternatives/explorer/alternatives
+++ b/type/__update_alternatives/explorer/alternatives
@@ -1,4 +1,25 @@
 #!/bin/sh -e
+#
+# 2020 Ander Punnar (ander at kvlt.ee)
+# 2021 Dennis Camera (skonfig at dtnr.ch)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
+# Print available alternatives.
+#
 
 LC_ALL=C update-alternatives --display "${__object_id:?}" 2>/dev/null \
 | awk -F ' - ' '/priority [0-9]+$/ { print $1 }'

--- a/type/__update_alternatives/explorer/alternatives
+++ b/type/__update_alternatives/explorer/alternatives
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 #
 # 2020 Ander Punnar (ander at kvlt.ee)
-# 2021 Dennis Camera (skonfig at dtnr.ch)
+# 2021 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__update_alternatives/explorer/link
+++ b/type/__update_alternatives/explorer/link
@@ -1,4 +1,23 @@
 #!/bin/sh -e
+#
+# 2020 Ander Punnar (ander at kvlt.ee)
+# 2021 Dennis Camera (skonfig at dtnr.ch)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
 
 # fedora's (update-)alternatives --display output doesn't have
 # "link <name> is <path>" line, but debian does. so, let's find

--- a/type/__update_alternatives/explorer/link
+++ b/type/__update_alternatives/explorer/link
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 #
 # 2020 Ander Punnar (ander at kvlt.ee)
-# 2021 Dennis Camera (skonfig at dtnr.ch)
+# 2021 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__update_alternatives/explorer/link
+++ b/type/__update_alternatives/explorer/link
@@ -18,6 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints the file path which is changed by this alternative.
+#
 
 # fedora's (update-)alternatives --display output doesn't have
 # "link <name> is <path>" line, but debian does. so, let's find

--- a/type/__update_alternatives/explorer/path_is
+++ b/type/__update_alternatives/explorer/path_is
@@ -18,6 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints the path currently used for the alternative.
+#
 
 path_is=$(
     LC_ALL=C update-alternatives --display "${__object_id?}" 2>/dev/null \

--- a/type/__update_alternatives/explorer/path_is
+++ b/type/__update_alternatives/explorer/path_is
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 #
 # 2020 Ander Punnar (ander at kvlt.ee)
-# 2021 Dennis Camera (skonfig at dtnr.ch)
+# 2021 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__update_alternatives/explorer/path_is
+++ b/type/__update_alternatives/explorer/path_is
@@ -1,4 +1,23 @@
 #!/bin/sh -e
+#
+# 2020 Ander Punnar (ander at kvlt.ee)
+# 2021 Dennis Camera (skonfig at dtnr.ch)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
 
 path_is=$(
     LC_ALL=C update-alternatives --display "${__object_id?}" 2>/dev/null \

--- a/type/__update_alternatives/explorer/path_should_state
+++ b/type/__update_alternatives/explorer/path_should_state
@@ -1,4 +1,23 @@
 #!/bin/sh -e
+#
+# 2020 Ander Punnar (ander at kvlt.ee)
+# 2021 Dennis Camera (skonfig at dtnr.ch)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
 
 if [ -f "$( cat "${__object:?}/parameter/path" )" ]
 then

--- a/type/__update_alternatives/explorer/path_should_state
+++ b/type/__update_alternatives/explorer/path_should_state
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 #
 # 2020 Ander Punnar (ander at kvlt.ee)
-# 2021 Dennis Camera (skonfig at dtnr.ch)
+# 2021 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__update_alternatives/explorer/path_should_state
+++ b/type/__update_alternatives/explorer/path_should_state
@@ -18,6 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints "present" if the path specified by --path exists, "absent" otherwise.
+#
 
 if [ -f "$( cat "${__object:?}/parameter/path" )" ]
 then

--- a/type/__update_alternatives/gencode-remote
+++ b/type/__update_alternatives/gencode-remote
@@ -1,22 +1,22 @@
 #!/bin/sh -e
 #
 # 2013 Nico Schottelius (nico-cdist at schottelius.org)
-# 2020 Ander Punnar (ander@kvlt.ee)
+# 2020 Ander Punnar (ander at kvlt.ee)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 
 path_is="$( cat "${__object:?}/explorer/path_is" )"
 

--- a/type/__update_alternatives/man.rst
+++ b/type/__update_alternatives/man.rst
@@ -43,7 +43,7 @@ SEE ALSO
 AUTHORS
 -------
 * Nico Schottelius <nico-cdist--@--schottelius.org>
-* Ander Punnar <ander@kvlt.ee>
+* Ander Punnar <ander--@--kvlt.ee>
 
 
 COPYING

--- a/type/__user/explorer/group
+++ b/type/__user/explorer/group
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
 # Get an existing groups group entry.
 #
 

--- a/type/__user/explorer/group
+++ b/type/__user/explorer/group
@@ -2,20 +2,20 @@
 #
 # 2011 Steven Armstrong (steven-cdist at armstrong.cc)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Get an existing groups group entry.

--- a/type/__user/explorer/passwd
+++ b/type/__user/explorer/passwd
@@ -2,20 +2,20 @@
 #
 # 2011 Steven Armstrong (steven-cdist at armstrong.cc)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Get an existing users passwd entry.

--- a/type/__user/explorer/passwd
+++ b/type/__user/explorer/passwd
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
 # Get an existing users passwd entry.
 #
 

--- a/type/__user/explorer/shadow
+++ b/type/__user/explorer/shadow
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
 # Get an existing users shadow entry.
 #
 

--- a/type/__user/explorer/shadow
+++ b/type/__user/explorer/shadow
@@ -2,20 +2,20 @@
 #
 # 2011 Steven Armstrong (steven-cdist at armstrong.cc)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Get an existing users shadow entry.

--- a/type/__user/gencode-remote
+++ b/type/__user/gencode-remote
@@ -21,22 +21,20 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Manage users.
-#
 
-name="$__object_id"
+name=${__object_id:?}
 
-os="$(cat "$__global/explorer/os")"
+os=$(cat "${__global:?}/explorer/os")
 
-state=$(cat "$__object/parameter/state")
+state=$(cat "${__object:?}/parameter/state")
 
 # We need to shorten options for both usermod and useradd since on some
 # systems (such as *BSD, Darwin) those commands do not handle GNU style long
 # options.
 shorten_property() {
-    unset ret
-    case "$1" in
+    unset -v ret
+    case $1
+    in
 	comment) ret="-c";;
 	home) ret="-d";;
 	gid) ret="-g";;

--- a/type/__user/gencode-remote
+++ b/type/__user/gencode-remote
@@ -4,22 +4,22 @@
 # 2011 Nico Schottelius (nico-cdist at schottelius.org)
 # 2013 Daniel Heule (hda at sfs.biz)
 # 2018 Thomas Eckert (tom at it-eckert.de)
-# 2022 Dennis Camera (cdist at dtnr.ch)
+# 2022 Dennis Camera (skonfig at dtnr.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Manage users.

--- a/type/__user/gencode-remote
+++ b/type/__user/gencode-remote
@@ -4,7 +4,7 @@
 # 2011 Nico Schottelius (nico-cdist at schottelius.org)
 # 2013 Daniel Heule (hda at sfs.biz)
 # 2018 Thomas Eckert (tom at it-eckert.de)
-# 2022 Dennis Camera (skonfig at dtnr.ch)
+# 2022 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__user/manifest
+++ b/type/__user/manifest
@@ -18,8 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-# Manage users.
-#
 
 case $(cat "${__global}/explorer/os")
 in

--- a/type/__user/manifest
+++ b/type/__user/manifest
@@ -1,22 +1,22 @@
 #!/bin/sh -e
 #
 # 2019 Nico Schottelius (nico-cdist at schottelius.org)
-# 2020,2022 Dennis Camera (cdist at dtnr.ch)
+# 2020,2022 Dennis Camera (skonfig at dtnr.ch)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 # Manage users.
 #

--- a/type/__user/manifest
+++ b/type/__user/manifest
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 #
 # 2019 Nico Schottelius (nico-cdist at schottelius.org)
-# 2020,2022 Dennis Camera (skonfig at dtnr.ch)
+# 2020,2022 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #

--- a/type/__user_groups/explorer/group
+++ b/type/__user_groups/explorer/group
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints the name of all groups --user is a member of.
+#
 
 user="$(cat "$__object/parameter/user" 2>/dev/null || echo "$__object_id")"
 

--- a/type/__user_groups/explorer/group
+++ b/type/__user_groups/explorer/group
@@ -2,20 +2,20 @@
 #
 # 2012 Steven Armstrong (steven-cdist at armstrong.cc)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 user="$(cat "$__object/parameter/user" 2>/dev/null || echo "$__object_id")"

--- a/type/__user_groups/explorer/oldusermod
+++ b/type/__user_groups/explorer/oldusermod
@@ -17,5 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Prints "true" if usermod(8) supports the -A option, "false" otherwise.
+#
 
 usermod --help | grep -q -- '-A group' && echo true || echo false

--- a/type/__user_groups/explorer/oldusermod
+++ b/type/__user_groups/explorer/oldusermod
@@ -2,20 +2,20 @@
 #
 # 2015 Heule Daniel (hda at sfs.biz)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 usermod --help | grep -q -- '-A group' && echo true || echo false

--- a/type/__user_groups/gencode-remote
+++ b/type/__user_groups/gencode-remote
@@ -2,20 +2,20 @@
 #
 # 2012 Steven Armstrong (steven-cdist at armstrong.cc)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 user="$(cat "$__object/parameter/user" 2>/dev/null || echo "$__object_id")"

--- a/type/__yum_repo/manifest
+++ b/type/__yum_repo/manifest
@@ -2,20 +2,20 @@
 #
 # 2014 Steven Armstrong (steven-cdist at armstrong.cc)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
 os=$(cat "$__global/explorer/os")

--- a/type/__zypper_repo/explorer/all_repo_ids
+++ b/type/__zypper_repo/explorer/all_repo_ids
@@ -17,9 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Retrieve all repo id nummbers - parsed zypper output.
 #
-# Retrieve all repo id nummbers - parsed zypper output
-#
-#
+
 # shellcheck disable=SC2005,SC2046
 echo $(zypper lr | cut -d'|' -f 1 | grep -E '^[0-9]')

--- a/type/__zypper_repo/explorer/all_repo_ids
+++ b/type/__zypper_repo/explorer/all_repo_ids
@@ -2,20 +2,20 @@
 #
 # 2013 Daniel Heule (hda at sfs.biz)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Retrieve all repo id nummbers - parsed zypper output

--- a/type/__zypper_repo/explorer/enabled_repo_ids
+++ b/type/__zypper_repo/explorer/enabled_repo_ids
@@ -17,10 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Retrieve all repo id nummbers from enabled repos - parsed zypper output.
 #
-# Retrieve all repo id nummbers from enabled repos - parsed zypper output
-#
-#
+
 # simpler command which works only on SLES11 SP3 or newer:
 # echo $(zypper lr -E | cut -d'|' -f 1 | grep -E '^[0-9]')
 #

--- a/type/__zypper_repo/explorer/enabled_repo_ids
+++ b/type/__zypper_repo/explorer/enabled_repo_ids
@@ -2,20 +2,20 @@
 #
 # 2013 Daniel Heule (hda at sfs.biz)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Retrieve all repo id nummbers from enabled repos - parsed zypper output

--- a/type/__zypper_repo/explorer/repo_id
+++ b/type/__zypper_repo/explorer/repo_id
@@ -17,10 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Retrieve the id from the repo with the uri from parameter uri  - parsed zypper output.
 #
-# Retrieve the id from the repo with the uri from parameter uri  - parsed zypper output
-#
-#
+
 if [ -f "$__object/parameter/uri" ]; then
    uri="$(cat "$__object/parameter/uri")"
 else

--- a/type/__zypper_repo/explorer/repo_id
+++ b/type/__zypper_repo/explorer/repo_id
@@ -2,20 +2,20 @@
 #
 # 2013-2014 Daniel Heule (hda at sfs.biz)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Retrieve the id from the repo with the uri from parameter uri  - parsed zypper output

--- a/type/__zypper_repo/gencode-remote
+++ b/type/__zypper_repo/gencode-remote
@@ -17,9 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Manage repo services with Zypper (mostly suse)
-#
 
 # Debug
 #exec >&2

--- a/type/__zypper_repo/gencode-remote
+++ b/type/__zypper_repo/gencode-remote
@@ -2,20 +2,20 @@
 #
 # 2013 Daniel Heule (hda at sfs.biz)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Manage repo services with Zypper (mostly suse)

--- a/type/__zypper_service/explorer/repo_ids
+++ b/type/__zypper_service/explorer/repo_ids
@@ -2,20 +2,20 @@
 #
 # 2013 Daniel Heule (hda at sfs.biz)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Manage services with Zypper (mostly suse)

--- a/type/__zypper_service/explorer/repo_ids
+++ b/type/__zypper_service/explorer/repo_ids
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-# Manage services with Zypper (mostly SuSE).
+# Prints the IDs of all configured zypper repositories.
 #
 
 # simpler command which works only on SLES11 SP3 or newer:

--- a/type/__zypper_service/explorer/repo_ids
+++ b/type/__zypper_service/explorer/repo_ids
@@ -17,10 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Manage services with Zypper (mostly SuSE).
 #
-# Manage services with Zypper (mostly suse)
-#
-#
+
 # simpler command which works only on SLES11 SP3 or newer:
 # echo $(zypper lr -u -E | cut -d'|' -f 1 | grep -E '^[0-9]')
 # on older systems, zypper doesn't know the parameter -E 

--- a/type/__zypper_service/explorer/service_id
+++ b/type/__zypper_service/explorer/service_id
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-# Manage services with Zypper (mostly SuSE).
+# Prints the ID of the zypper service configured to use --uri.
 #
 
 if [ -f "$__object/parameter/uri" ]; then

--- a/type/__zypper_service/explorer/service_id
+++ b/type/__zypper_service/explorer/service_id
@@ -2,20 +2,20 @@
 #
 # 2013 Daniel Heule (hda at sfs.biz)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Manage services with Zypper (mostly suse)

--- a/type/__zypper_service/explorer/service_id
+++ b/type/__zypper_service/explorer/service_id
@@ -17,9 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Manage services with Zypper (mostly SuSE).
 #
-# Manage services with Zypper (mostly suse)
-#
+
 if [ -f "$__object/parameter/uri" ]; then
    uri="$(cat "$__object/parameter/uri")"
 else

--- a/type/__zypper_service/explorer/service_ids
+++ b/type/__zypper_service/explorer/service_ids
@@ -2,20 +2,20 @@
 #
 # 2013 Daniel Heule (hda at sfs.biz)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Manage services with Zypper (mostly suse)

--- a/type/__zypper_service/explorer/service_ids
+++ b/type/__zypper_service/explorer/service_ids
@@ -17,9 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Manage services with Zypper (mostly SuSE)
 #
-# Manage services with Zypper (mostly suse)
-#
+
 # simpler command which works only on SLES11 SP3 or newer:
 # echo $(zypper ls -u -E | cut -d'|' -f 1 | grep -E '^[0-9]')
 #

--- a/type/__zypper_service/explorer/service_ids
+++ b/type/__zypper_service/explorer/service_ids
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-# Manage services with Zypper (mostly SuSE)
+# Prints the IDs of all enabled zypper services.
 #
 
 # simpler command which works only on SLES11 SP3 or newer:

--- a/type/__zypper_service/explorer/service_uri
+++ b/type/__zypper_service/explorer/service_uri
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-# Manage services with Zypper (mostly SuSE)
+# Prints the --uri if a repository using it is configured.
 #
 
 if [ -f "$__object/parameter/uri" ]; then

--- a/type/__zypper_service/explorer/service_uri
+++ b/type/__zypper_service/explorer/service_uri
@@ -2,20 +2,20 @@
 #
 # 2013 Daniel Heule (hda at sfs.biz)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Manage services with Zypper (mostly suse)

--- a/type/__zypper_service/explorer/service_uri
+++ b/type/__zypper_service/explorer/service_uri
@@ -17,9 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
+# Manage services with Zypper (mostly SuSE)
 #
-# Manage services with Zypper (mostly suse)
-#
+
 if [ -f "$__object/parameter/uri" ]; then
    uri="$(cat "$__object/parameter/uri")"
 else

--- a/type/__zypper_service/gencode-remote
+++ b/type/__zypper_service/gencode-remote
@@ -2,20 +2,20 @@
 #
 # 2013 Daniel Heule (hda at sfs.biz)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Manage services with Zypper (mostly suse)

--- a/type/__zypper_service/gencode-remote
+++ b/type/__zypper_service/gencode-remote
@@ -17,9 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Manage services with Zypper (mostly suse)
-#
 
 # Debug
 #exec >&2

--- a/type/__zypper_service/manifest
+++ b/type/__zypper_service/manifest
@@ -2,20 +2,20 @@
 #
 # 2013 Daniel Heule (hda at sfs.biz)
 #
-# This file is part of cdist.
+# This file is part of skonfig-base.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig-base is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig-base is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 # Manage services with Zypper (mostly suse)

--- a/type/__zypper_service/manifest
+++ b/type/__zypper_service/manifest
@@ -17,9 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# Manage services with Zypper (mostly suse)
-#
 
 # Debug
 #exec >&2


### PR DESCRIPTION
- updated project name (`cdist` &rarr; `skonfig-base`)
- unified e-mail "obfuscation" and format
- added copyright header to files where it was missing
  - reconstructed copyright from Git log as good as possible
- updated "post-copyright" descriptions
  - removed from non-explorers
  - added to explorers where missing