### PR TITLE
Replace test -a, -o

### DIFF
--- a/explorer/init
+++ b/explorer/init
@@ -164,7 +164,7 @@ check_busybox_init() (
 check_dinit() {
 	init_exe=${1:-/sbin/dinit}
 	test -x "${init_exe}" || return 1
-	test -S /run/dinitctl -o -S /var/run/dinitctl || return 1
+	test -S /run/dinitctl || test -S /var/run/dinitctl || return 1
 	echo dinit
 }
 

--- a/explorer/machine_type
+++ b/explorer/machine_type
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2021,2023 Dennis Camera (dennis.camera at riiengineering.ch)
+# 2021,2023,2025 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #
@@ -59,7 +59,8 @@ files_notsame() {
 		read -r _  # skip header line
 		read -r fs1 _ _ _ _ mp1
 		read -r fs2 _ _ _ _ mp2
-		test "${fs1}" = "${fs2}" -a "${mp1}" = "${mp2}" || return 0
+		test "${fs1}" = "${fs2}" || return 0
+		test "${mp1}" = "${mp2}" || return 0
 	} &&
 	ls -1Ldi "$1" "$2" 2>/dev/null | {
 		read -r ino1 _
@@ -172,7 +173,7 @@ check_chroot_procfs() (
 	then
 		is_chroot=true
 	fi
-	if test -e /proc/1/mountinfo -a -e /proc/self/mountinfo
+	if test -e /proc/1/mountinfo && test -e /proc/self/mountinfo
 	then
 		has_mountinfo=true
 		cmp -s /proc/1/mountinfo /proc/self/mountinfo || is_chroot=true
@@ -235,7 +236,7 @@ check_ct_systemd() (
 )
 
 has_ct_pid_1() {
-	test -r /run/systemd/container -o -r /proc/1/environ
+	test -r /run/systemd/container || test -r /proc/1/environ
 }
 
 translate_container_name() {
@@ -293,15 +294,17 @@ check_ct_cgroup() {
 }
 
 check_ct_files() {
-	if test -e /.dockerenv -o -e /run/.dockerenv -o -e /.dockerinit
+	if test -e /.dockerenv || test -e /run/.dockerenv || test -e /.dockerinit
 	then
 		echo docker
 	elif test -f /run/.containerenv
 	then
 		# https://github.com/containers/podman/issues/3586#issuecomment-661918679
 		echo podman
-	elif test -d /proc/vz -a ! -d /proc/bc -a -f /proc/user_beancounters \
-		|| test -d /.cpt_hardlink_dir_*/
+	elif { test -d /proc/vz \
+			&& ! test -d /proc/bc \
+			&& test -f /proc/user_beancounters
+		} || test -d /.cpt_hardlink_dir_*/
 	then
 		# Virtuozzo / OpenVZ
 		#
@@ -484,7 +487,7 @@ check_vm_arch_specific() {
 
 			if test -e /dev/mdesc
 			then
-				if test -d /sys/class/vlds/ctrl -a -d /sys/class/vlds/sp
+				if test -d /sys/class/vlds/ctrl && test -d /sys/class/vlds/sp
 				then
 					# control LDom
 					return 1
@@ -522,7 +525,7 @@ check_vm_arch_specific() {
 			fi
 			;;
 		(ia64)
-			if test -d /sys/bus/xen -a ! -d /sys/bus/xen-backend
+			if test -d /sys/bus/xen && ! test -d /sys/bus/xen-backend
 			then
 				# PV-on-HVM drivers installed in a Xen guest
 				echo xen-hvm
@@ -720,7 +723,7 @@ check_vm_hyp_specific() {
 		return 0
 	elif test -d /proc/xen
 	then
-		test -r /proc/xen/capabilities &&
+		test -r /proc/xen/capabilities || return 1
 		if grep -q -F 'control_d' /proc/xen/capabilities 2>/dev/null
 		then
 			# Xen dom0

--- a/type/__file/explorer/cksum
+++ b/type/__file/explorer/cksum
@@ -25,7 +25,7 @@ destination="/${__object_id:?}"
 
 read -r state_should <"${__object:?}/parameter/state"
 
-if test -f "${destination}" -a "${state_should}" = 'present'
+if test -f "${destination}" && test "${state_should}" = 'present'
 then
 	# only calculate cksum if --state present, because it is ignored for other
 	# --states

--- a/type/__hostname/explorer/max_len
+++ b/type/__hostname/explorer/max_len
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2019 Dennis Camera (dennis.camera at riiengineering.ch)
+# 2019,2025 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #
@@ -24,7 +24,10 @@ command -v getconf >/dev/null || exit 0
 
 val=$(getconf HOST_NAME_MAX 2>/dev/null) || exit 0
 
-if test -n "${val}" -a "${val}" != 'undefined'
-then
-	echo "${val}"
-fi
+case ${val}
+in
+	(undefined)
+		;;
+	(?*)
+		echo "${val}" ;;
+esac

--- a/type/__hostname/gencode-remote
+++ b/type/__hostname/gencode-remote
@@ -2,7 +2,7 @@
 #
 # 2014-2017 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2014 Nico Schottelius (nico-cdist at schottelius.org)
-# 2019 Dennis Camera (dennis.camera at riiengineering.ch)
+# 2019,2025 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #
@@ -94,9 +94,9 @@ in
             # exit with non-zero when it fails (e.g. hostname too long,
             # D-Bus failure, etc.).
 
-            echo "hostnamectl set-hostname \"\$(cat /etc/hostname)\""
-            echo "test \"\$(hostname)\" = \"\$(cat /etc/hostname)\"" \
-                 " || hostname -F /etc/hostname"
+            # shellcheck disable=SC2016
+            echo 'hostnamectl set-hostname "$(cat /etc/hostname)"'
+            echo 'hostname -F /etc/hostname'
         else
             printf "echo 'Unsupported OS: %s' >&2\n" "${os}"
             printf 'exit 1\n'

--- a/type/__hostname/manifest
+++ b/type/__hostname/manifest
@@ -2,7 +2,7 @@
 #
 # 2012 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2014 Nico Schottelius (nico-cdist at schottelius.org)
-# 2019 Dennis Camera (dennis.camera at riiengineering.ch)
+# 2019,2025 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #
@@ -48,7 +48,7 @@ else
     esac
 fi
 
-if test -n "${max_len}" && test "$(printf '%s' "${name_should}" | wc -c)" -gt "${max_len}"
+if test -n "${max_len}" && test "${#name_should}" -gt "${max_len}"
 then
     printf 'Host name too long. Up to %u characters allowed.\n' "${max_len}" >&2
     exit 1
@@ -171,7 +171,7 @@ in
         # not work correctly on openSUSE 12.x which provides
         # hostnamectl but not /etc/hostname.
 
-        if test -n "${has_hostnamectl}" -a "${os_major}" -gt 12
+        if test -n "${has_hostnamectl}" && test "${os_major}" -gt 12
         then
             hostname_file=/etc/hostname
         else

--- a/type/__localedef/gencode-remote
+++ b/type/__localedef/gencode-remote
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 #
 # 2013-2019 Nico Schottelius (nico-cdist at schottelius.org)
-# 2020 Dennis Camera (dennis.camera at riiengineering.ch)
+# 2020,2025 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #
@@ -25,17 +25,20 @@
 state_is=$(cat "${__object:?}/explorer/state")
 state_should=$(cat "${__object:?}/parameter/state")
 
-test "${state_should}" = 'present' -o "${state_should}" = 'absent' || {
-	printf 'Invalid --state: %s\n' "${state_should}" >&2
-	exit 1
-}
-
-# NOTE: If state explorer fails (e.g. locale(1) missing), the following check
-#       will always fail and let definition/removal run.
-if test "${state_is}" = "${state_should}"
-then
-	exit 0
-fi
+case ${state_should}
+in
+	("${state_is}")
+		# NOTE: If state explorer fails (e.g. locale(1) missing), the following check
+		#       will always fail and let definition/removal run.
+		exit 0
+		;;
+	(present|absent)
+		;;
+	(*)
+		printf 'Invalid --state: %s\n' "${state_should}" >&2
+		exit 1
+		;;
+esac
 
 locale=${__object_id:?}
 os=$(cat "${__global:?}/explorer/os")

--- a/type/__package_apt/gencode-remote
+++ b/type/__package_apt/gencode-remote
@@ -73,7 +73,8 @@ aptget='DEBIAN_FRONTEND=noninteractive apt-get --quiet --yes -o Dpkg::Options::=
 case ${state_should}
 in
     (present)
-        if test -n "${version_should}" -a "${version_should}" != "${version_is}"
+        if test -n "${version_should}" \
+           && test "${version_should}" != "${version_is}"
         then
             # other version should be installed
             name="${name}=${version_should}"
@@ -151,7 +152,10 @@ EOF
         ;;
     (absent)
         if test "${state_is}" != 'absent' \
-        || test -f "${__object:?}/parameter/purge-if-absent" -a "${config_state}" != 'purged'
+           || {
+               test -f "${__object:?}/parameter/purge-if-absent" \
+               && test "${config_state}" != 'purged'
+           }
         then
             echo "${aptget} remove ${purgeparam} '${name_is}'"
             echo 'removed' >>"${__messages_out:?}"

--- a/type/__user/explorer/shadow
+++ b/type/__user/explorer/shadow
@@ -41,7 +41,7 @@ then
   # shellcheck disable=SC2015
   getent "${database}" "${name}" 2>/dev/null && exit || :  # fallback to file
 fi
-if test -n "${database}" -a -f "/etc/${database}"
+if test -f "/etc/${database}"
 then
   awk -v name="${name}" -F: '$1 == name' "/etc/${database}"
 fi


### PR DESCRIPTION
`test -a` and `test -o` have been removed from the POSIX.1-2024 standard.

I think we should thus also remove usage from skonfig.

https://pubs.opengroup.org/onlinepubs/9799919799/utilities/test.html#tag_20_121_25