### PR TITLE
__systemd_unit: stop unit if state=disabled and --restart

### DIFF
--- a/type/__systemd_unit/gencode-remote
+++ b/type/__systemd_unit/gencode-remote
@@ -46,7 +46,8 @@ fi
 
 if [ -f "${__object:?}/parameter/restart" ]
 then
-    if [ "${desired_enablement_state}" = 'masked' ]
+    if [ "${desired_enablement_state}" = 'masked' ] \
+        || [ "${desired_enablement_state}" = 'disabled' ]
     then
         if [ "${unit_status}" = 'active' ]
         then


### PR DESCRIPTION
Note to self: this type is out of hand and messy, should rewrite it.

This is actually fix and I'm confused why I haven't noticed this problem before.

If I disable unit, then I expect unit to be stopped, right? Well, now it is like this.