### PR TITLE
explorer: Initial Haiku/BeOS support

### DIFF
--- a/explorer/cpu_cores
+++ b/explorer/cpu_cores
@@ -2,6 +2,7 @@
 #
 # 2014 Daniel Heule (hda at sfs.biz)
 # 2014 Thomas Oettli (otho at sfs.biz)
+# 2025 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #
@@ -25,6 +26,12 @@
 os=$("${__explorer:?}/os")
 case ${os}
 in
+    (beos)
+        sysinfo -cpu | grep -c '^CPU #[0-9][0-9]*'
+        ;;
+    (haiku)
+        nproc
+        ;;
     (macosx)
         sysctl -n hw.physicalcpu
         ;;

--- a/explorer/disks
+++ b/explorer/disks
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 #
 # based on previous work by other people, modified by:
-# 2020,2022-2023 Dennis Camera (dennis.camera at riiengineering.ch)
+# 2020,2022-2023,2025 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #
@@ -25,6 +25,10 @@ uname_s=$(uname -s)
 
 case ${uname_s}
 in
+    (BeOS|Haiku)
+        find /dev/disk -type c -name 'raw' \
+            ! -path '*/atapi/*' ! -path '*/floppy/*' ! -path '*/virtual/*'
+        ;;
     (FreeBSD)
         sysctl -n kern.disks
         ;;

--- a/explorer/init
+++ b/explorer/init
@@ -2,7 +2,7 @@
 #
 # 2016 Daniel Heule (hda at sfs.biz)
 # 2017 Philippe Gregoire (pg at pgregoire.xyz)
-# 2020,2023 Dennis Camera (dennis.camera at riiengineering.ch)
+# 2020,2023,2025 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #
@@ -29,6 +29,8 @@
 #    busybox-init+openrc
 #  ArchLinux:
 #    systemd, sysvinit
+#  BeOS:
+#    (no output, has no init)
 #  Chimera Linux:
 #    dinit
 #  CRUX:
@@ -39,6 +41,8 @@
 #    sysvinit, sysvinit+openrc
 #  Gentoo:
 #    sysvinit+openrc, openrc-init, systemd
+#  Haiku:
+#    launch_daemon
 #  OpenBMC:
 #    systemd
 #  OpenWrt:
@@ -197,6 +201,11 @@ check_launchd() {
 	echo launchd
 }
 
+check_launch_daemon() {
+	command -v launch_roster >/dev/null 2>&1 || return 1
+	echo launch_daemon
+}
+
 check_openrc() {
 	test -f /run/openrc/softlevel || return 1
 	echo openrc
@@ -304,6 +313,9 @@ guess_by_path() {
 	in
 		(/bin/busybox)
 			check_busybox_init "$1" && return
+			;;
+		(/boot/system/servers/launch_daemon)
+			check_launch_daemon "$1" && return
 			;;
 		(/lib/systemd/systemd)
 			check_systemd "$1" && return
@@ -428,6 +440,31 @@ find_init() {
 			;;
 		(FreeBSD)
 			find_init_procfs || find_init_ps
+			;;
+		(BeOS)
+			# BeOS does not have an init program like other UNIX systems.
+			# Being a desktop OS it does not have services or such things known
+			# from other Unices.
+			# It has some shell scripts (/boot/beos/system/boot/Bootscript & co)
+			# to start and stop some programs, that’s all.
+			exit 0
+			;;
+		(Haiku)
+			# NOTE: Haiku is special in that it does not have an init
+			#       program like other UNIX systems.
+			#       Beginning with Haiku R1/beta1, the OS has some
+			#       sort of service manager, but it is not the parent
+			#       of all other processes, so the common detection
+			#       strategies don't work.
+			if test -x /boot/system/servers/launch_daemon
+			then
+				echo /boot/system/servers/launch_daemon
+			else
+				# Older versions of Haiku boot using Bootscript (like BeOS, but
+				# located in /boot/system/boot/Bootscript) and don't have
+				# services or such things.
+				exit 0
+			fi
 			;;
 		(OpenBSD)
 			find_init_pgrep || find_init_ps

--- a/explorer/interfaces
+++ b/explorer/interfaces
@@ -1,6 +1,7 @@
 #!/bin/sh -e
 #
 # 2019 Ander Punnar (ander at kvlt.ee)
+# 2019,2025 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #
@@ -22,11 +23,23 @@
 # Output is sorted lexicographically.
 #
 
-if command -v ip >/dev/null
+if command -v ip >/dev/null 2>&1
 then
 	ip -o link show | sed -n 's/^[0-9]\+: \(.\+\): <.*/\1/p'
-elif command -v ifconfig >/dev/null
+elif command -v ifconfig >/dev/null 2>&1
 then
-	ifconfig -a | sed -n -E 's/^(.*)(:[[:space:]]*flags=|Link encap).*/\1/p'
+	os=$("${__explorer:?}/os")
+	case ${os}
+	in
+		(beos|haiku)
+			ifconfig \
+			| sed -n -e 's/^\([^[:blank:]]\{1,\}\)\([[:blank:]]*Hardware type:.*\)\{0,1\}$/\1/p'
+			;;
+		(*)
+			ifconfig -a | sed -n \
+				-e 's/^\([^[:blank:]]*\):[[:blank:]]*flags=.*$/\1/p' \
+				-e 's/^\([^[:blank:]]*\)[[:blank:]]*Link encap.*$/\1/p'
+			;;
+	esac
 fi \
 | sort -u

--- a/explorer/machine
+++ b/explorer/machine
@@ -1,6 +1,7 @@
 #!/bin/sh
 #
 # 2010-2011 Andi Brönnimann (andi-cdist at v-net.ch)
+# 2025 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #
@@ -20,7 +21,37 @@
 # Prints the processor architecture of the target.
 #
 
-if command -v uname >/dev/null 2>&1
-then
-   uname -m
-fi
+command -v uname >/dev/null 2>&1 || exit 0
+
+case $(uname -s)
+in
+	(BeOS|Haiku)
+		# NOTE: On BeOS/Haiku uname -m will print machine names like BePC,
+		#       BeBox, BeMac, etc.
+		#       uname -p is more helpful in printing the processor architecture,
+		#       but it will print "unknown" many times (esp. original BeOS).
+		#       So we need some logic to try to squeeze out something helpful.
+		#       Will print nothing if both uname -mp print "unknown".
+		proc=$(uname -p)
+		case ${proc}
+		in
+			(unknown)
+				proc=$(uname -m)
+				# fall back to guessing based on uname -m
+				case ${proc}
+				in
+					(BePC|Intel)
+						proc=x86 ;;
+					(BeMac|BeBox)
+						proc=ppc ;;
+					(unknown)
+						proc= ;;
+				esac
+				;;
+		esac
+		${proc:+echo "${proc}"}
+		;;
+	(*)
+		uname -m
+		;;
+esac

--- a/explorer/memory
+++ b/explorer/memory
@@ -3,7 +3,7 @@
 # 2014 Daniel Heule (hda at sfs.biz)
 # 2014 Thomas Oettli (otho at sfs.biz)
 # 2017 Philippe Gregoire (pg at pgregoire.xyz)
-# 2020 Dennis Camera (dennis.camera at riiengineering.ch)
+# 2020-2021,2025 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #
@@ -45,6 +45,17 @@ bytes2kib() {
 
 case $(uname -s)
 in
+	(BeOS|Haiku)
+		bytes=$(sysinfo -mem | sed -n -e 's#^.*(used/max *\([0-9]*\) */ *\([0-9]*\))$#\2#p')
+		awk -v bytes="${bytes}" '
+		BEGIN {
+			if (0 > bytes) {
+				# whoops, signed 32-bit integer overflow...
+				bytes = (2**32 + bytes)
+			}
+			printf "%.f\n", (bytes / 1024)
+		}'
+		;;
 	(Darwin)
 		sysctl -n hw.memsize | bytes2kib
 		;;

--- a/explorer/os
+++ b/explorer/os
@@ -2,7 +2,7 @@
 #
 # 2010-2011 Nico Schottelius (nico-cdist at schottelius.org)
 # 2017 Philippe Gregoire (pg at pgregoire.xyz)
-# 2019-2020,2023 Dennis Camera (dennis.camera at riiengineering.ch)
+# 2019-2020,2023-2025 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #
@@ -210,6 +210,14 @@ case $(uname -s)
 in
    (Darwin)
       echo macosx
+      exit 0
+      ;;
+   (BeOS)
+      echo beos
+      exit 0
+      ;;
+   (Haiku)
+      echo haiku
       exit 0
       ;;
    (NetBSD)

--- a/explorer/os_version
+++ b/explorer/os_version
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 #
 # 2010-2011 Nico Schottelius (nico-cdist at schottelius.org)
-# 2020-2023 Dennis Camera (dennis.camera at riiengineering.ch)
+# 2020-2023,2025 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #
@@ -143,6 +143,16 @@ in
       ;;
    (*bsd|solaris)
       uname -r
+      ;;
+   (beos)
+      # Original BeOS ended at 5.1 (Exp/Dano)
+      # Zeta then continued versions at 6.0 (e.g. Zeta 1.1 is uname -r: 6.0.1).
+      uname -r
+      ;;
+   (haiku)
+      # Haiku restarted versioning at 1.0, being a rewrite of BeOS.
+      # Unfortunately, uname -r is hard-coded to "1", though.
+      version /boot/system/lib/libbe.so
       ;;
    (openwrt)
       cat /etc/openwrt_version


### PR DESCRIPTION
This is more of experimental nature, but still cool to show what skonfig can run on.

Support for the Haiku OS is implemented in the global explorers (modulo `machine_type`).
Haiku R1/beta has been tested and returns sensible values.

Some of the core types could be supported as well in the future.

BeOS has been added more or less as well, but I could only manually test it, because neither BeOS R5 nor Zeta wanted to boot in QEMU/VirtualBox.
I could get it running on actual hardware, but R5 does not support the network card and for Zeta I only have a Live CD which does not want to network because `/` is read-only, so...
SSHd should be possible, but doesn't make much sense without networking.
