### PR TITLE
explorer: Detect Adélie Linux

### DIFF
--- a/explorer/os
+++ b/explorer/os
@@ -171,6 +171,12 @@ then
    exit 0
 fi
 
+if test -f /etc/adelie-release
+then
+   echo adelie
+   exit 0
+fi
+
 if test -f /etc/owl-release
 then
    echo owl

--- a/explorer/os_version
+++ b/explorer/os_version
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 #
 # 2010-2011 Nico Schottelius (nico-cdist at schottelius.org)
-# 2020-2023 Dennis Camera (dennis.camera at riiengineering.ch)
+# 2020-2023,2025 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #
@@ -27,16 +27,20 @@
 rc_getvar() {
    awk -F= -v varname="$2" '
       function unquote(s) {
-         if (s ~ /^".*"$/ || s ~ /^'\''.*'\''$/)
+         if (s ~ /^".*"$/ || s ~ /^'\''.*'\''$/) {
             return substr(s, 2, length(s) - 2)
-         else
+         } else {
             return s
+         }
       }
       $1 == varname { print unquote(substr($0, index($0, "=") + 1)) }' "$1"
 }
 
 case $("${__explorer:?}/os")
 in
+   (adelie)
+      rc_getvar /etc/os-release VERSION_ID
+      ;;
    (amazon)
       cat /etc/system-release
       ;;


### PR DESCRIPTION
Implement support for [Adélie Linux](https://www.adelielinux.org/) in global explorers.

I only updated `os` and `os_version` because it's just a standard Linux distribution, so the others should not require any changes for Adélie.