### PR TITLE
explorer/os_version: Report only version numbers

### DIFF
--- a/explorer/os_version
+++ b/explorer/os_version
@@ -41,12 +41,25 @@ in
    (adelie)
       rc_getvar /etc/os-release VERSION_ID
       ;;
+   (alpine)
+      cat /etc/alpine-release
+      ;;
    (amazon)
       cat /etc/system-release
       ;;
    (archlinux)
       # empty, but well...
       cat /etc/arch-release
+      ;;
+   (beos)
+      # Original BeOS ended at 5.1 (Exp/Dano)
+      # Zeta then continued versions at 6.0 (e.g. Zeta 1.1 is uname -r: 6.0.1).
+      if libbe_version=$(version /boot/system/lib/libbe.so 2>/dev/null)
+      then
+         printf '%s\n' "${libbe_version#R}"
+      else
+         uname -r
+      fi
       ;;
    (checkpoint)
       awk '{version=$NF; printf("%s\n", substr(version, 2))}' /etc/cp-release
@@ -126,14 +139,7 @@ in
       echo "${devuan_version}"
       ;;
    (fedora)
-      cat /etc/fedora-release
-      ;;
-   (gentoo)
-      cat /etc/gentoo-release
-      ;;
-   (macosx)
-      # NOTE: Legacy versions (< 10.3) do not support options
-      sw_vers | awk -F ':[ \t]+' '$1 == "ProductVersion" { print $2 }'
+      sed -e 's/^Fedora\( Core\)* release \(.*\) (.*)$/\2/' /etc/fedora-release
       ;;
    (freebsd)
       # Apparently uname -r is not a reliable way to get the patch level.
@@ -147,37 +153,47 @@ in
          uname -r
       fi
       ;;
-   (*bsd|solaris)
-      uname -r
-      ;;
-   (beos)
-      # Original BeOS ended at 5.1 (Exp/Dano)
-      # Zeta then continued versions at 6.0 (e.g. Zeta 1.1 is uname -r: 6.0.1).
-      uname -r
+   (gentoo)
+      cat /etc/gentoo-release
       ;;
    (haiku)
       # Haiku restarted versioning at 1.0, being a rewrite of BeOS.
-      # Unfortunately, uname -r is hard-coded to "1", though.
-      version /boot/system/lib/libbe.so
+      # uname -r is hard-coded to "1", so we ignore it.
+      libbe_version=$(version /boot/system/lib/libbe.so 2>/dev/null) || exit 0
+      printf '%s\n' "${libbe_version#R}"
+      ;;
+   (macosx)
+      # NOTE: Legacy versions (< 10.3) do not support options
+      sw_vers | awk -F ':[ \t]+' '$1 == "ProductVersion" { print $2 }'
       ;;
    (openwrt)
-      cat /etc/openwrt_version
+      if test -r /etc/openwrt_release
+      then
+         # since the LEDE fork (17.01 or OpenWrt 18.06), /etc/openwrt_version
+         # contains a commit ID (e.g. r7808-ef686b7292) instead of the
+         # release version.
+         rc_getvar /etc/openwrt_release DISTRIB_RELEASE
+      else
+         cat /etc/openwrt_version
+      fi
       ;;
    (owl)
       cat /etc/owl-release
       ;;
    (redhat|centos|almalinux|eurolinux|rocky|mitel|scientific)
-      cat /etc/redhat-release
+      sed -e 's/^\([A-Za-z]* \)*release \(.*\) (.*)$/\2/' /etc/redhat-release
       ;;
    (slackware)
-      cat /etc/slackware-version
+      sed -e 's/^Slackware //' /etc/slackware-version
       ;;
    (suse)
-      if [ -f /etc/os-release ]
+      if test -f /etc/os-release
       then
-        cat /etc/os-release
+         rc_getvar /etc/os-release VERSION_ID
       else
-        cat /etc/SuSE-release
+         # fall back to original /etc/SuSE-release (deprecated since SuSE 13,
+         # removed in 15)
+         sed -n -e 's/^VERSION *= *//p' /etc/SuSE-release
       fi
       ;;
    (ubuntu|pop-os)
@@ -196,7 +212,15 @@ in
          rc_getvar /etc/lsb-release DISTRIB_RELEASE
       fi
       ;;
-   (alpine)
-       cat /etc/alpine-release
-       ;;
+   (*bsd|solaris)
+      # NOTE: this section has to be at the bottom because of the wildcard.
+      #       The freebsd section above should take precedence.
+      uname -r
+      ;;
+   (*)
+      if test -r /etc/os-release
+      then
+         rc_getvar /etc/os-release VERSION_ID
+      fi
+      ;;
 esac

--- a/explorer/os_version
+++ b/explorer/os_version
@@ -112,6 +112,7 @@ in
             # decode codename
             case ${devuan_codename%%/*}
             in
+               (freia) devuan_version=7 ;;
                (excalibur) devuan_version=6 ;;
                (daedalus) devuan_version=5 ;;
                (chimaera) devuan_version=4 ;;

--- a/type/__hostname/manifest
+++ b/type/__hostname/manifest
@@ -155,22 +155,16 @@ in
         echo "${name_should}" | __file /etc/nodename --source -
         ;;
     (suse)
-        if test -s "${__global:?}/explorer/os_release"
-        then
-            # shellcheck source=/dev/null
-            os_version=$(. "${__global:?}/explorer/os_release" && echo "${VERSION}")
-        else
-            os_version=$(sed -n 's/^VERSION\ *=\ *//p' "${__global:?}/explorer/os_version")
-        fi
-        os_major=$(expr "${os_version}" : '\([0-9]\{1,\}\)')
+        read -r os_version <"${__global:?}/explorer/os_version"
+        os_major=${os_version%%[!0-9]*}
 
         # Classic SuSE stores the FQDN in /etc/HOSTNAME, while
         # systemd does not. The running hostname is the first
         # component in both cases.
         # In versions before 15.x, the FQDN is stored in /etc/hostname.
         if test -n "${has_hostnamectl}" \
-                && test "${os_major}" -ge 15 \
-                && test "${os_major}" -ne 42
+                && test $((os_major)) -ge 15 \
+                && test $((os_major)) -ne 42
         then
             # strip away everything but the first part from $name_should
             name_should=${name_should%%.*}
@@ -184,7 +178,7 @@ in
         # not work correctly on openSUSE 12.x which provides
         # hostnamectl but not /etc/hostname.
 
-        if test -n "${has_hostnamectl}" && test "${os_major}" -gt 12
+        if test -n "${has_hostnamectl}" && test $((os_major)) -gt 12
         then
             hostname_file=/etc/hostname
         else

--- a/type/__hwclock/manifest
+++ b/type/__hwclock/manifest
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2020 Dennis Camera (dennis.camera at riiengineering.ch)
+# 2020,2025 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #
@@ -63,31 +63,30 @@ in
 		fi
 		;;
 	(centos|fedora|redhat|scientific)
-		os_version=$(cat "${__global:?}/explorer/os_version")
-		os_major=$(expr "${os_version}" : '.* release \([0-9]*\)')
+		read -r os_version <"${__global:?}/explorer/os_version"
+		os_major=${os_version%%[!0-9]*}
 		case ${os}
 		in
-			(centos|scientific)
-				update_sysconfig=$(test "${os_major}" -lt 6 && echo true || echo false)
+			(centos|almalinux|rocky|scientific|eurolinux)
+				update_sysconfig=$(test $((os_major)) -lt 6 && echo true || echo false)
 				;;
 			(fedora)
-				update_sysconfig=$(test "${os_major}" -lt 10 && echo true || echo false)
+				update_sysconfig=$(test $((os_major)) -lt 10 && echo true || echo false)
 				;;
-			(redhat|*)
-				case ${os_version}
-				in
-					('Red Hat Enterprise Linux'*)
-						update_sysconfig=$(test "${os_major}" -lt 6 && echo true || echo false)
-						;;
-					('Red Hat Linux'*)
-						update_sysconfig=true
-						;;
-					(*)
-						printf 'Could not determine Red Hat distribution.\n' >&2
-						printf "Please contribute an implementation for it if you can.\n" >&2
-						exit 1
-						;;
-				esac
+			(redhat)
+				read -r init <"${__global:?}/explorer/init"
+				if test $((os_major)) -lt 6 || test "${init}" = sysvinit
+				then
+					# Red Hat Linux (original) or RHEL < 6
+					update_sysconfig=true
+				else
+					update_sysconfig=false
+				fi
+				;;
+			(*)
+				printf 'Could not determine Red Hat distribution.\n' >&2
+				printf "Please contribute an implementation for it if you can.\n" >&2
+				exit 1
 				;;
 		esac
 
@@ -105,15 +104,15 @@ in
 		fi
 		;;
 	(debian|devuan|ubuntu)
-		os_major=$(sed 's/[^0-9].*$//' "${__global:?}/explorer/os_version")
+		read -r os_version <"${__global:?}/explorer/os_version"
 
 		case ${os}
 		in
 			(debian)
-				if test "${os_major}" -ge 7
+				if test "${os_version%%.*}" -ge 7
 				then
 					update_rcS=false
-				elif test "${os_major}" -ge 3
+				elif test "${os_version%%.*}" -ge 3
 				then
 					update_rcS=true
 				else
@@ -123,7 +122,7 @@ in
 					# Debian 2.1 uses the ancient GMT key.
 					# Debian 1.3 does not have rcS.
 					printf "Your operating system (Debian %s) is currently not supported by this type (%s)\n" \
-						"$(cat "${__global:?}/explorer/os_version")" "${__type##*/}" >&2
+						"${os_version}" "${__type##*/}" >&2
 					printf "Please contribute an implementation for it if you can.\n" >&2
 					exit 1
 				fi
@@ -132,11 +131,11 @@ in
 				update_rcS=false
 				;;
 			(ubuntu)
-				update_rcS=$(test "${os_major}" -lt 16 && echo true || echo false)
+				update_rcS=$(test "${os_version%%.*}" -lt 16 && echo true || echo false)
 				;;
 		esac
 
-		if ${update_rcS}
+		if ${update_rcS?}
 		then
 			export CDIST_ORDER_DEPENDENCY=true
 			__file /etc/default/rcS --state present \
@@ -180,12 +179,12 @@ in
 			# shellcheck source=/dev/null
 			os_version=$(. "${__global:?}/explorer/os_release" && echo "${VERSION}")
 		else
-			os_version=$(sed -n 's/^VERSION\ *=\ *//p' "${__global:?}/explorer/os_version")
+			read -r os_version <"${__global:?}/explorer/os_version"
 		fi
 		os_major=$(expr "${os_version}" : '\([0-9]\{1,\}\)')
 
 		# TODO: Consider using `yast2 timezone set hwclock' instead
-		if expr "${os_major}" \< 12
+		if test "${os_version%%.*}" -lt 12
 		then
 			# Starting with SuSE 12 (first systemd-based version)
 			# /etc/sysconfig/clock does not contain the HWCLOCK line

--- a/type/__locale_system/manifest
+++ b/type/__locale_system/manifest
@@ -3,7 +3,7 @@
 # 2012-2016 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2016 Carlos Ortigoza (carlos.ortigoza at ungleich.ch)
 # 2016 Nico Schottelius (nico.schottelius at ungleich.ch)
-# 2020,2022-2023 Dennis Camera (dennis.camera at riiengineering.ch)
+# 2020,2022-2023,2025 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #
@@ -169,17 +169,11 @@ in
         key="export ${__object_id:?}"
         ;;
     (suse)
-        if test -s "${__global:?}/explorer/os_release"
-        then
-            # shellcheck source=/dev/null
-            os_version=$(. "${__global:?}/explorer/os_release" && echo "${VERSION}")
-        else
-            os_version=$(sed -n 's/^VERSION\ *=\ *//p' "${__global:?}/explorer/os_version")
-        fi
-        os_major=$(expr "${os_version}" : '\([0-9]\{1,\}\)')
+        read -r os_version <"${__global:?}/explorer/os_version"
+        os_major=${os_version%%[!0-9]*}
 
         # https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-suse.html#sec-suse-l10n
-        if expr "${os_major}" '>=' 15 \& "${os_major}" != 42
+        if test $((os_major)) -ge 15 && test $((os_major)) -ne 42
         then
             # It seems that starting with SuSE 15 the systemd /etc/locale.conf
             # is the preferred way to set locales, although

--- a/type/__localedef/gencode-remote
+++ b/type/__localedef/gencode-remote
@@ -119,7 +119,7 @@ in
 		case ${state_should}
 		in
 			(present)
-				if expr "$(grep -o -e '^[0-9]*' "${__global:?}/explorer/os_version")" '>=' 11 >/dev/null
+				if awk '{ exit !(int($0) >= 11) }' "${__global:?}/explorer/os_version"
 				then
 					# localedef(1) is available with FreeBSD >= 11
 					printf "localedef -i %s -f %s %s\n" \

--- a/type/__start_on_boot/gencode-remote
+++ b/type/__start_on_boot/gencode-remote
@@ -2,6 +2,7 @@
 #
 # 2012-2013 Nico Schottelius (nico-cdist at schottelius.org)
 # 2016 Daniel Heule (hda at sfs.biz)
+# 2018,2023,2025 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #
@@ -28,13 +29,12 @@ target_runlevel=$(cat "${__object:?}/parameter/target_runlevel")
 [ "${state_should}" = "${state_is}" ] && exit 0
 
 os=$(cat "${__global:?}/explorer/os")
-os_version=$(cat "${__global:?}/explorer/os_version")
 name=${__object_id:?}
 
 case ${state_should}
 in
     (present)
-        if [ "${init}" = 'systemd' ]
+        if test "${init}" = 'systemd'
         then
             # this handles ALL linux distros with systemd
             # e.g. archlinux, gentoo in some cases, new RHEL and SLES versions
@@ -42,23 +42,7 @@ in
         else
             case ${os}
             in
-                (debian)
-                    case ${os_version}
-                    in
-                        ([1-7]*)
-                            echo "update-rc.d '${name}' defaults >/dev/null"
-                            ;;
-                        (8*)
-                            echo "systemctl enable '${name}'"
-                            ;;
-                        (*)
-                            echo "Unsupported version ${os_version} of ${os}" >&2
-                            exit 1
-                            ;;
-                    esac
-                    ;;
-
-                (devuan)
+                (debian|devuan)
                     echo "update-rc.d '${name}' defaults >/dev/null"
                     ;;
 
@@ -74,7 +58,7 @@ in
                     # 'enable' can be successful and still return a non-zero exit
                     # code, deal with it by checking for success ourselves in that
                     # case (the || ... part).
-                    echo "'/etc/init.d/${name}' enable || [ -f /etc/rc.d/S??'${name}' ]"
+                    echo "'/etc/init.d/${name}' enable || test -f /etc/rc.d/S??'${name}'"
                     ;;
 
                 (ubuntu)


### PR DESCRIPTION
For some operating systems the explorer result varied between operating systems. For some, a whole release file was printed, making output expecially hard to parse by other types.

* BeOS: Try to report userland version (libbe.so) if possible, fall back to uname -r. libbe.so version is more fine grained (e.g. R5.0.3) over uname -r (5.0).
* Haiku: Strip leading R from version.
* Fedora/Red Hat: report only version number, no more distro name and release codename.
* OpenWrt: report version number for all releases. For 17.01 and later a (pretty useless) commit ID was reported.
* SuSE: report only version number, no more whole SuSE-release/os-release.
* Slackware: Strip Slackware prefix, version number only.
* others: extract VERSION_ID from /etc/os-release if available.

Ordered case labels lexicographically.