### PR TITLE
Silence stderr for command -v

### DIFF
--- a/explorer/hostname
+++ b/explorer/hostname
@@ -20,7 +20,7 @@
 # Prints the running hostname.
 #
 
-if command -v hostname >/dev/null
+if command -v hostname >/dev/null 2>&1
 then
 	hostname
 else

--- a/explorer/init
+++ b/explorer/init
@@ -259,7 +259,7 @@ check_sysvinit() (
 )
 
 check_upstart() {
-	test -x "$(command -v initctl)" || return 1
+	test -x "$(command -v initctl 2>/dev/null)" || return 1
 	case $(initctl version)
 	in
 		(*'(upstart '*')')

--- a/explorer/lsb_codename
+++ b/explorer/lsb_codename
@@ -31,8 +31,8 @@ in
       (. /etc/openwrt_release && echo "${DISTRIB_CODENAME}")
       ;;
    (*)
-      lsb_release=$(command -v lsb_release)
-      if [ -x "${lsb_release}" ]
+      lsb_release=$(command -v lsb_release 2>/dev/null)
+      if test -x "${lsb_release}"
       then
          ${lsb_release} --short --codename
       fi

--- a/explorer/lsb_description
+++ b/explorer/lsb_description
@@ -31,8 +31,8 @@ in
       (. /etc/openwrt_release && echo "${DISTRIB_DESCRIPTION}")
       ;;
    (*)
-      lsb_release=$(command -v lsb_release)
-      if [ -x "${lsb_release}" ]
+      lsb_release=$(command -v lsb_release 2>/dev/null)
+      if test -x "${lsb_release}"
       then
          ${lsb_release} --short --description
       fi

--- a/explorer/lsb_id
+++ b/explorer/lsb_id
@@ -31,8 +31,8 @@ in
       (. /etc/openwrt_release && echo "${DISTRIB_ID}")
       ;;
    (*)
-      lsb_release=$(command -v lsb_release)
-      if [ -x "${lsb_release}" ]
+      lsb_release=$(command -v lsb_release 2>/dev/null)
+      if test -x "${lsb_release}"
       then
          ${lsb_release} --short --id
       fi

--- a/explorer/lsb_release
+++ b/explorer/lsb_release
@@ -31,8 +31,8 @@ in
       (. /etc/openwrt_release && echo "${DISTRIB_RELEASE}")
       ;;
    (*)
-      lsb_release=$(command -v lsb_release)
-      if [ -x "${lsb_release}" ]
+      lsb_release=$(command -v lsb_release 2>/dev/null)
+      if test -x "${lsb_release}"
       then
          ${lsb_release} --short --release
       fi

--- a/explorer/runlevel
+++ b/explorer/runlevel
@@ -21,7 +21,7 @@
 #
 
 set +e
-executable=$(command -v runlevel)
+executable=$(command -v runlevel 2>/dev/null)
 if [ -x "${executable}" ]
 then
    "${executable}" | awk '{ print $2 }'

--- a/type/__git/explorer/group
+++ b/type/__git/explorer/group
@@ -36,7 +36,7 @@ then
 	then
 		printf '%u\n' "${group_gid}"
 	else
-		if command -v getent >/dev/null
+		if command -v getent >/dev/null 2>&1
 		then
 			getent group "${group_gid}" | cut -d : -f 1
 		else

--- a/type/__group/explorer/group
+++ b/type/__group/explorer/group
@@ -30,7 +30,7 @@ not_supported() {
 
 name=${__object_id:?}
 
-if command -v getent >/dev/null
+if command -v getent >/dev/null 2>&1
 then
 	getent group "${name}" || :
 elif test -f /etc/group

--- a/type/__group/explorer/gshadow
+++ b/type/__group/explorer/gshadow
@@ -39,7 +39,7 @@ in
 		;;
 esac
 
-if command -v getent >/dev/null
+if command -v getent >/dev/null 2>&1
 then
 	getent gshadow "${name}" || :
 elif test -f /etc/gshadow

--- a/type/__hostname/explorer/max_len
+++ b/type/__hostname/explorer/max_len
@@ -20,7 +20,7 @@
 # Prints the maximum length of a host name if defined on the system.
 #
 
-command -v getconf >/dev/null || exit 0
+command -v getconf >/dev/null 2>&1 || exit 0
 
 val=$(getconf HOST_NAME_MAX 2>/dev/null) || exit 0
 

--- a/type/__key_value/explorer/state
+++ b/type/__key_value/explorer/state
@@ -56,7 +56,7 @@ else
 fi
 export key state delimiter value exact_delimiter
 
-awk_bin=$(PATH=$(getconf PATH 2>/dev/null) && command -v awk || echo awk)
+awk_bin=$(PATH=$(getconf PATH 2>/dev/null) && command -v awk 2>/dev/null || echo awk)
 
 "${awk_bin}" -f - "${file}" <<"AWK_EOF"
 BEGIN {

--- a/type/__key_value/files/remote_script.sh
+++ b/type/__key_value/files/remote_script.sh
@@ -47,7 +47,7 @@ else
     touch "${file}"
 fi
 
-awk_bin=$(PATH=$(getconf PATH 2>/dev/null) && command -v awk || echo awk)
+awk_bin=$(PATH=$(getconf PATH 2>/dev/null) && command -v awk 2>/dev/null || echo awk)
 
 "${awk_bin}" -f - "${file}" >"${tmpfile}" <<'AWK_EOF'
 BEGIN {

--- a/type/__package/explorer/pkgng_exists
+++ b/type/__package/explorer/pkgng_exists
@@ -17,10 +17,10 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-# Retrieve the status of a package - parsed dpkg output
+# Print the path of the pkg(8) command if on FreeBSD.
 #
 
 if [ "$("${__explorer:?}/os")" = 'freebsd' ]
 then
-   command -v pkg
+   command -v pkg 2>/dev/null
 fi

--- a/type/__package_apt/gencode-remote
+++ b/type/__package_apt/gencode-remote
@@ -96,7 +96,7 @@ in
                 # because the state explorer will report all packages as manual
                 # for those.
                 # shellcheck disable=SC2016
-                echo 'if ! head -n1 "$(command -v apt-mark)" | grep -qF python'
+                echo 'if ! head -n1 "$(command -v apt-mark 2>/dev/null)" | grep -qF python'
 
                 # new C++ implementation (Debian >= 7)
                 echo "then apt-mark manual '${name_is}' >/dev/null"

--- a/type/__ssh_authorized_keys/explorer/file
+++ b/type/__ssh_authorized_keys/explorer/file
@@ -32,7 +32,7 @@ else
 		owner=${__object_id:?}
 	fi
 
-	if command -v getent >/dev/null
+	if command -v getent >/dev/null 2>&1
 	then
 		owner_line=$(getent passwd "${owner}")
 	elif [ -f /etc/passwd ]
@@ -57,7 +57,7 @@ else
 	then
 		# Don't know how to determine user's home directory, fall back to ~
 		home="~${owner}"
-		command -v realpath >/dev/null && home=$(realpath "${home}")
+		command -v realpath >/dev/null 2>&1 && home=$(realpath "${home}")
 	fi
 
 	[ -d "${home}" ] && echo "${home}/.ssh/authorized_keys"

--- a/type/__ssh_authorized_keys/explorer/group
+++ b/type/__ssh_authorized_keys/explorer/group
@@ -28,7 +28,7 @@ else
 	owner=${__object_id:?}
 fi
 
-if command -v getent >/dev/null
+if command -v getent >/dev/null 2>&1
 then
 	gid=$(getent passwd "${owner}" | cut -d':' -f4)
 	getent group "${gid}" || :

--- a/type/__ssh_dot_ssh/explorer/group
+++ b/type/__ssh_dot_ssh/explorer/group
@@ -23,7 +23,7 @@
 
 gid=$("${__type_explorer:?}/passwd" | cut -d':' -f4)
 
-if command -v getent >/dev/null
+if command -v getent >/dev/null 2>&1
 then
 	getent group "${gid}" || :
 else

--- a/type/__ssh_dot_ssh/explorer/passwd
+++ b/type/__ssh_dot_ssh/explorer/passwd
@@ -24,7 +24,7 @@
 
 owner=${__object_id:?}
 
-if command -v getent >/dev/null
+if command -v getent >/dev/null 2>&1
 then
     getent passwd "${owner}" || :
 else

--- a/type/__user/explorer/group
+++ b/type/__user/explorer/group
@@ -23,7 +23,7 @@
 if [ -f "${__object:?}/parameter/gid" ]
 then
    gid=$(cat "${__object:?}/parameter/gid")
-   if command -v getent >/dev/null
+   if command -v getent >/dev/null 2>&1
    then
       getent group "${gid}" || :
    elif [ -f /etc/group ]

--- a/type/__user/explorer/passwd
+++ b/type/__user/explorer/passwd
@@ -22,7 +22,7 @@
 
 name=${__object_id:?}
 
-if command -v getent >/dev/null
+if command -v getent >/dev/null 2>&1
 then
   getent passwd "${name}" || :
 elif [ -f /etc/passwd ]


### PR DESCRIPTION
Old versions of bash print an error message to stderr if the command cannot be found which clobbers stderr and skonfig dump unnecessarily with useless error messages:

	stderr/remote: /var/lib/skonfig/conf/explorer/lsb_codename: line 1: command: lsb_release: not found
	stderr/remote: /var/lib/skonfig/conf/explorer/lsb_id: line 1: command: lsb_release: not found
	stderr/remote: /var/lib/skonfig/conf/explorer/lsb_description: line 1: command: lsb_release: not found
    stderr/remote: /var/lib/skonfig/conf/explorer/lsb_release: line 1: command: lsb_release: not found
