### PR TITLE
__uci_section: Fix unquoting UCI values

### DIFF
--- a/type/__uci_section/files/option_state.awk
+++ b/type/__uci_section/files/option_state.awk
@@ -26,7 +26,7 @@ function unquote(s) {
 	# simplified dequoting of single quoted strings
 	if (s ~ /^'.*'$/) {
 		s = substr(s, 2, length(s) - 2)
-		sub(/'\\''/, "'", s)
+		gsub(/'\\''/, "'", s)
 	}
 	return s
 }


### PR DESCRIPTION
When values contain single quotes, `sub()` only removes the first embedded quote.

e.g. in `/etc/config/openvpn`:

	option tls_version_min '1.2 '\''or-highest'\'''

was unquoted to: `1.2 'or-highest'\''`
instead of: `1.2 'or-highest'`