### PR TITLE
Set `LC_ALL=C` for all usages of comm(1), sort(1), tr(1)

### DIFF
--- a/explorer/cpu_sockets
+++ b/explorer/cpu_sockets
@@ -31,7 +31,7 @@ in
     (*)
         if test -r /proc/cpuinfo
         then
-            sockets=$(grep -e '^physical id[[:blank:]]*:' /proc/cpuinfo | sort -u | wc -l)
+            sockets=$(grep -e '^physical id[[:blank:]]*:' /proc/cpuinfo | LC_ALL=C sort -u | wc -l)
             if test $((sockets)) -lt 1
             then
                 sockets=$(grep -c -e '^processor[[:blank:]]*:' /proc/cpuinfo)

--- a/explorer/interfaces
+++ b/explorer/interfaces
@@ -42,4 +42,4 @@ then
 			;;
 	esac
 fi \
-| sort -u
+| LC_ALL=C sort -u

--- a/explorer/machine_type
+++ b/explorer/machine_type
@@ -204,7 +204,7 @@ check_chroot_procfs() (
 				EOF
 				printf '%s\n' "${hmntpnt%"${cmntpnt}"}"
 			done </proc/self/mountinfo \
-			| sort -u \
+			| LC_ALL=C sort -u \
 			| head -n 1  # just take the first...
 		fi
 
@@ -440,12 +440,12 @@ check_vm_cpuinfo() {
 			  do
 				  guess_hypervisor_from_cpu_model "${_cpu_model}"
 			  done \
-			| sort \
+			| LC_ALL=C sort \
 			| uniq -c \
 			| awk '
 			  { if ($1 > most_c) { most_c = $1; most_s = $2 } }
 			  END {
-				if (most_s) print most_s
+				if (most_s) { print most_s }
 				exit !most_s
 			  }' \
 			&& return 0

--- a/type/__acl/gencode-remote
+++ b/type/__acl/gencode-remote
@@ -57,7 +57,7 @@ fi
 # users/groups in target is most common reason.
 echo "${acl_should}" \
     | grep -o -e 'user:[^:]\{1,\}' -e 'group:[^:]\{1,\}' \
-    | sort -u \
+    | LC_ALL=C sort -u \
     | while read -r l
     do
         grep -qxF -e "${l}" "${__object:?}/explorer/getent" || {
@@ -70,7 +70,7 @@ if [ -f "${__object:?}/parameter/default" ]
 then
     acl_should=$(echo "${acl_should}" \
         | sed 's/^default://' \
-        | sort -u \
+        | LC_ALL=C sort -u \
         | sed 's/\(.*\)/default:\1\n\1/')
 fi
 

--- a/type/__locale_system/manifest
+++ b/type/__locale_system/manifest
@@ -31,7 +31,7 @@ version_ge() {
 	# NOTES: if the lowest value of the two version numbers is equal to
 	#        `min_version_expected`, `version_is` must be the same or larger.
 	#        `-k n,n` instead of `-k n` is required for some sort(1)s.
-	sort -t. -n -k1,1 -k2,2 -k3,3 <<-EOF | { read -r _x; test "${_x}" = "$2"; }
+	LC_ALL=C sort -t. -n -k1,1 -k2,2 -k3,3 <<-EOF | { read -r _x; test "${_x}" = "$2"; }
 	$1
 	$2
 	EOF

--- a/type/__localedef/explorer/state
+++ b/type/__localedef/explorer/state
@@ -58,7 +58,7 @@ format_locale() {
 
 gnu_normalize_codeset() {
 	# reimplementation of glibc/locale/programs/localedef.c normalize_codeset()
-	echo "$*" | tr '[:upper:]' '[:lower:]' | tr -cd '[:alnum:]'
+	echo "$*" | LC_ALL=C tr -cd '[:alnum:]' | LC_ALL=C tr '[:upper:]' '[:lower:]'
 }
 
 locale_available() (

--- a/type/__localedef/files/lib/glibc.sh
+++ b/type/__localedef/files/lib/glibc.sh
@@ -19,5 +19,5 @@
 #
 
 gnu_normalize_codeset() {
-	echo "$*" | tr -cd '[:alnum:]' | tr '[:upper:]' '[:lower:]'
+	echo "$*" | LC_ALL=C tr -cd '[:alnum:]' | LC_ALL=C tr '[:upper:]' '[:lower:]'
 }

--- a/type/__package_emerge/gencode-remote
+++ b/type/__package_emerge/gencode-remote
@@ -43,7 +43,7 @@ then
     echo 'Package name is not unique! The following packages are installed:' >&2
     echo "${pkg_version}" >&2
     exit 1
-elif [ -n "${version}" ] && [ "$(echo "${pkg_version}" | cut -d ' ' -f 1 | sort | uniq | wc -l)" -gt 1 ]
+elif [ -n "${version}" ] && [ "$(echo "${pkg_version}" | cut -d ' ' -f 1 | LC_ALL=C sort -u | wc -l)" -gt 1 ]
 then
     echo 'Package name is not unique! The following packages are installed:' >&2
     echo "${pkg_version}" >&2

--- a/type/__sensible_editor/manifest
+++ b/type/__sensible_editor/manifest
@@ -28,7 +28,7 @@ version_ge() {
 	# NOTES: if the lowest value of the two version numbers is equal to
 	#        `min_version_expected`, `version_is` must be the same or larger.
 	#        `-k n,n` instead of `-k n` is required for some sort(1)s.
-	sort -t. -n -k1,1 -k2,2 -k3,3 <<-EOF | { read -r _x; test "${_x}" = "$2"; }
+	LC_ALL=C sort -t. -n -k1,1 -k2,2 -k3,3 <<-EOF | { read -r _x; test "${_x}" = "$2"; }
 	$1
 	$2
 	EOF

--- a/type/__ssh_authorized_key/explorer/entry
+++ b/type/__ssh_authorized_key/explorer/entry
@@ -57,4 +57,5 @@ awk -v tk="${type_and_key}" <"${file}" '
 		}
 	}
 }
-' | sort
+' \
+| LC_ALL=C sort

--- a/type/__ssh_authorized_key/gencode-remote
+++ b/type/__ssh_authorized_key/gencode-remote
@@ -89,7 +89,7 @@ remove_lines() {
 	cat <<-EOF
 	tmpfile=\$(mktemp $(shquot "${1:?}.skonfig.XXXXXX"))
 	grep -v -x -F \\
-	$(printf '%s\n' "${2:?}" | sort -u | sed -e "s/'/'\\\\''/g" -e "s/^.*\$/       -e '&' \\\\/")
+	$(printf '%s\n' "${2:?}" | LC_ALL=C sort -u | sed -e "s/'/'\\\\''/g" -e "s/^.*\$/       -e '&' \\\\/")
 	<$(shquot "${1:?}") >"\${tmpfile}" || :
 	cat "\${tmpfile}" >$(shquot "${1:?}")
 	rm -f "\${tmpfile}"
@@ -134,7 +134,7 @@ in
 			# ensure that the files are sorted for comparison with comm(1).
 			remove_lines \
 				"${file}" \
-				"$(printf '%s\n' "${entry_should}" | comm -13 - "${__object:?}/explorer/entry")"
+				"$(printf '%s\n' "${entry_should}" | LC_ALL=C comm -13 - "${__object:?}/explorer/entry")"
 		fi
 
 		key_present_count=$(grep -c -x -F -e "${entry_should}" "${__object:?}/explorer/entry") || :

--- a/type/__sshd_config/explorer/config_file
+++ b/type/__sshd_config/explorer/config_file
@@ -31,7 +31,7 @@ version_ge() {
 	#        `min_version_expected`, `version_is` must be the same or larger.
 	#        `-k n,n` instead of `-k n` is required for some sort(1)s.
 	printf '%s\n' "$1" "$2" \
-	| sort -t '.' -n -k 1,1 -k 2,2 -k 3,3 \
+	| LC_ALL=C sort -t '.' -n -k 1,1 -k 2,2 -k 3,3 \
 	| head -1 \
 	| grep -qxF -e "$2"
 }

--- a/type/__sshd_config/explorer/state
+++ b/type/__sshd_config/explorer/state
@@ -29,7 +29,7 @@
 #
 
 joinlines() { sed -n -e H -e "\${x;s/^\\n//;s/\\n/${1:?}/g;p;}"; }
-trlower() { tr '[:upper:]' '[:lower:]'; }
+trlower() { LC_ALL=C tr '[:upper:]' '[:lower:]'; }
 tolower() { printf '%s' "$*" | trlower; }
 
 default_value() {

--- a/type/__uci/files/functions.sh
+++ b/type/__uci/files/functions.sh
@@ -48,7 +48,7 @@ uci_cmd() {
 
 uci_validate_name() {
 	# like util.c uci_validate_name()
-	test -n "$*" && test -z "$(echo "$*" | tr -d '[:alnum:]_')"
+	test -n "$*" && test -z "$(echo "$*" | LC_ALL=C tr -d '[:alnum:]_')"
 }
 
 uci_validate_tuple() (

--- a/type/__uci/files/uci_apply.sh
+++ b/type/__uci/files/uci_apply.sh
@@ -48,7 +48,7 @@ rollback() {
 
 	uci changes \
 	| sed -e 's/^-//' -e 's/\..*\$//' \
-	| sort -u \
+	| LC_ALL=C sort -u \
 	| while read -r _package
 	  do
 		  uci revert "${_package}"

--- a/type/__uci_section/files/functions.sh
+++ b/type/__uci_section/files/functions.sh
@@ -64,7 +64,8 @@ uci_cmd() {
 
 uci_validate_name() {
 	# like util.c uci_validate_name()
-	test -n "$*" && test -z "$(printf %s "$*" | tr -d '[:alnum:]_' | tr -c '' .)"
+	test -n "$*" \
+	&& test -z "$(printf '%s' "$*" | LC_ALL=C tr -d '[:alnum:]_' | tr -c '' .)"
 }
 
 unquote_lines() {

--- a/type/__uci_section/gencode-remote
+++ b/type/__uci_section/gencode-remote
@@ -60,13 +60,15 @@ in
 		if test -f "${__object:?}/parameter/list"
 		then
 			listnames_should=$(
-				sed -e 's/=.*$//' "${__object:?}/parameter/list" | sort -u)
+				sed -e 's/=.*$//' "${__object:?}/parameter/list" \
+				| LC_ALL=C sort -u)
 		fi
 
 		if test -f "${__object:?}/parameter/option"
 		then
 			optnames_should=$(
-				sed -e 's/=.*$//' "${__object:?}/parameter/option" | sort -u)
+				sed -e 's/=.*$//' "${__object:?}/parameter/option" \
+				| LC_ALL=C sort -u)
 		fi
 
 		# Make sure the section itself is present

--- a/type/__uci_section/manifest
+++ b/type/__uci_section/manifest
@@ -71,7 +71,7 @@ in
 		if test -s "${__object:?}/parameter/option"
 		then
 			sed -e 's/=.*$//' "${__object:?}/parameter/option" \
-			| sort \
+			| LC_ALL=C sort \
 			| uniq -d \
 			| print_errors \
 				  'Found duplicate --options:' \

--- a/type/__unpack/test/README
+++ b/type/__unpack/test/README
@@ -1,3 +1,3 @@
 ./make-test-files.sh
 ./make-init-manifest.sh | cdist config -i - localhost
-sudo find /tmp/cdist__unpack_test/ -type f -exec cat {} \; | sort
+sudo find /tmp/cdist__unpack_test/ -type f -exec cat {} \; | LC_ALL=C sort

--- a/type/__unpack/test/make-init-manifest.sh
+++ b/type/__unpack/test/make-init-manifest.sh
@@ -8,7 +8,7 @@ echo 'export CDIST_ORDER_DEPENDENCY=1'
 echo "__directory $d"
 
 find "$p" -name 'test.*' -and -not -name '*.cdist__unpack_sum' \
-    | sort \
+    | LC_ALL=C sort \
     | while read -r l
 do
     n="$( basename "$l" )"

--- a/type/__user_groups/explorer/group
+++ b/type/__user_groups/explorer/group
@@ -1,6 +1,7 @@
 #!/bin/sh
 #
 # 2012 Steven Armstrong (steven-cdist at armstrong.cc)
+# 2025 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #
@@ -20,6 +21,11 @@
 # Prints the name of all groups --user is a member of.
 #
 
-user=$(cat "${__object:?}/parameter/user" 2>/dev/null || echo "${__object_id:?}")
+if test -f "${__object:?}/parameter/user"
+then
+	user=$(cat "${__object:?}/parameter/user")
+else
+	user=${__object_id:?}
+fi
 
-(id -G -n "${user}" | tr ' ' '\n' | sort) 2>/dev/null || :
+id -G -n "${user}" 2>/dev/null | tr ' ' '\n' | LC_ALL=C sort

--- a/type/__user_groups/gencode-remote
+++ b/type/__user_groups/gencode-remote
@@ -1,6 +1,7 @@
 #!/bin/sh -e
 #
 # 2012 Steven Armstrong (steven-cdist at armstrong.cc)
+# 2025 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #
@@ -18,26 +19,33 @@
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
-user=$(cat "${__object:?}/parameter/user" 2>/dev/null || echo "${__object_id:?}")
+if test -f "${__object:?}/parameter/user"
+then
+	user=$(cat "${__object:?}/parameter/user")
+else
+	user=${__object_id:?}
+fi
 state_should=$(cat "${__object:?}/parameter/state")
 oldusermod=$(cat "${__object:?}/explorer/oldusermod")
 os=$(cat "${__global:?}/explorer/os")
 
-mkdir "${__object:?}/files"
-# file has to be sorted for comparison with `comm`
-sort "${__object:?}/parameter/group" >"${__object:?}/files/group.sorted"
+get_changed_groups() {
+   # groups have to be sorted for comparison with comm(1).
+   LC_ALL=C sort "${__object:?}/parameter/group" \
+   | LC_ALL=C comm "$@" "${__object:?}/explorer/group" -
+}
 
 case ${state_should}
 in
    (present)
-      changed_groups=$(comm -13 "${__object:?}/explorer/group" "${__object:?}/files/group.sorted")
+      changed_groups=$(get_changed_groups -13)
       ;;
    (absent)
-      changed_groups=$(comm -12 "${__object:?}/explorer/group" "${__object:?}/files/group.sorted")
+      changed_groups=$(get_changed_groups -12)
       ;;
 esac
 
-if [ -z "${changed_groups}" ]
+if test -z "${changed_groups}"
 then
    # Nothing to do, move along
    exit 0


### PR DESCRIPTION
For tr(1) I only set `$LC_ALL` when character classes or ranges are used.

All three utilities are dependant on the locale setting. And especially when locale can differ between the local system and the target, sorting order can vary, leading to unexpected bugs.
Also regex character classes and ranges can vary depending on locale.