### PR TITLE
__uci: Fix line count

### DIFF
--- a/type/__uci/gencode-remote
+++ b/type/__uci/gencode-remote
@@ -45,7 +45,7 @@ in
 				;;
 			('')
 				# Guess type by the number of values
-				if test "$(wc -l "${__object:?}/parameter/value")" -gt 1
+				if test "$(wc -l <"${__object:?}/parameter/value")" -gt 1
 				then
 					type=list
 				else


### PR DESCRIPTION
Passing data to wc(1) via stdin stops it from printing the input file name.

This fixes:

    object/__uci/.../stderr/gencode-remote: .../type/__uci/gencode-remote: 48: test: Illegal number: 1 /tmp/.../parameter/value