### PR TITLE
__apt_source: Fix regression and lint

### DIFF
--- a/type/__apt_source/files/source.list.template
+++ b/type/__apt_source/files/source.list.template
@@ -6,14 +6,15 @@ entry="${uri:?} ${distribution:?} ${component:?}"
 options="${forcedarch-} ${signed_by-}"
 options=${options## }; options=${options%% } # Trim spaces from either end
 
-cat << DONE
-# Created by cdist ${__type##*/}
-# Do not change. Changes will be overwritten.
+# header
+cat <<EOF
+# Managed by skonfig (${__type##*/}).
+# Changes will be overwritten.
 #
 
 # ${name:?}
 deb ${options:+[${options}] }${entry}
-DONE
+EOF
 if [ -f "${__object:?}/parameter/include-src" ]
 then
    echo "deb-src ${signed_by:+[${signed_by}] }${entry}"

--- a/type/__apt_source/files/source.list.template
+++ b/type/__apt_source/files/source.list.template
@@ -1,10 +1,32 @@
 #!/bin/sh -eu
+#
+# 2011-2018 Steven Armstrong (steven-cdist at armstrong.cc)
+# 2022 Daniel Fancsali (fancsali at gmail.com)
+# 2022,2025 Dennis Camera (dennis.camera at riiengineering.ch)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
 
 : "${__type:?}"  # make shellcheck happy
 
 entry="${uri:?} ${distribution:?} ${component:?}"
-options="${forcedarch-} ${signed_by-}"
-options=${options## }; options=${options%% } # Trim spaces from either end
+
+options_src="${signed_by-}"
+options="${forcedarch-} ${options_src-}"
+options=${options# }; options=${options% } # trim space from either end
 
 # header
 cat <<EOF
@@ -13,9 +35,10 @@ cat <<EOF
 #
 
 # ${name:?}
-deb ${options:+[${options}] }${entry}
 EOF
-if [ -f "${__object:?}/parameter/include-src" ]
+
+printf 'deb %s%s\n' "${options:+[${options}] }" "${entry}"
+if test -f "${__object:?}/parameter/include-src"
 then
-   echo "deb-src ${signed_by:+[${signed_by}] }${entry}"
+	printf 'deb-src %s%s\n' "${options_src:+[${options_src}] }" "${entry}"
 fi

--- a/type/__apt_source/files/source.list.template
+++ b/type/__apt_source/files/source.list.template
@@ -1,6 +1,6 @@
 #!/bin/sh -eu
 
-: "${__type:?}" "${options:?}"  # make shellcheck happy
+: "${__type:?}"  # make shellcheck happy
 
 entry="${uri:?} ${distribution:?} ${component:?}"
 options="${forcedarch-} ${signed_by-}"

--- a/type/__apt_source/files/source.list.template
+++ b/type/__apt_source/files/source.list.template
@@ -19,23 +19,14 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
-
-: "${__type:?}"  # make shellcheck happy
+# Generate the APT source definition in one-line-style format.
+#
 
 entry="${uri:?} ${distribution:?} ${component:?}"
 
 options_src="${signed_by-}"
 options="${forcedarch-} ${options_src-}"
 options=${options# }; options=${options% } # trim space from either end
-
-# header
-cat <<EOF
-# Managed by skonfig (${__type##*/}).
-# Changes will be overwritten.
-#
-
-# ${name:?}
-EOF
 
 printf 'deb %s%s\n' "${options:+[${options}] }" "${entry}"
 if test -f "${__object:?}/parameter/include-src"

--- a/type/__apt_source/gencode-remote
+++ b/type/__apt_source/gencode-remote
@@ -21,21 +21,18 @@
 name=${__object_id:?}
 destination="/etc/apt/sources.list.d/${name}.list"
 
-# There are special arguments to apt(8) to prevent aborts if apt woudn't been
-# updated after the 19th April 2021 till the bullseye release. The additional
-# arguments acknoledge the happend suite change (the apt(8) update does the
-# same by itself).
+# Allow release info changes to prevent apt-get(8) aborts e.g. if APT wasn't
+# updated between 2021-04-19 and the bullseye release.
+# The additional arguments acknowledge the suite change (apt(8) update
+# does the same by itself).
 #
-# Using '-o $config' instead of the --allow-releaseinfo-change-* parameter
-# allows backward compatablility to pre-buster Debian versions.
-#
-# See more: ticket #861
-# https://code.ungleich.ch/ungleich-public/cdist/-/issues/861
+# Using ’-o’ instead of the --allow-releaseinfo-change-* parameters
+# allows backwards compatibility with pre-buster APT versions.
 apt_opts='-o Acquire::AllowReleaseInfoChange::Suite=true -o Acquire::AllowReleaseInfoChange::Version=true'
 
-# run 'apt-get update' only if something changed with our sources.list file
-#   it will be run a second time on error as a redundancy messure to success
+# Run 'apt-get update' only if something changed in our sources.list file
+# it will be run a second time on error as a redundancy measure to success.
 if grep -q "^__file${destination}" "${__messages_in:?}"
 then
-   printf 'apt-get %s update || apt-get %s update\n' "${apt_opts}" "${apt_opts}"
+	printf 'apt-get %s update || apt-get %s update\n' "${apt_opts}" "${apt_opts}"
 fi

--- a/type/__apt_source/man.rst
+++ b/type/__apt_source/man.rst
@@ -3,7 +3,7 @@ cdist-type__apt_source(7)
 
 NAME
 ----
-cdist-type__apt_source - Manage apt sources
+cdist-type__apt_source - Manage APT sources
 
 
 DESCRIPTION
@@ -15,20 +15,22 @@ when needed so call of index updating type is not needed.
 REQUIRED PARAMETERS
 -------------------
 uri
-   the uri to the apt repository
+   The URI to the APT repository.
 
 
 OPTIONAL MULTIPLE PARAMETERS
 ----------------------------
 signed-by
-   provide a GPG key fingerprint or keyring path for signature checks.
+   Provide a GPG key fingerprint or keyring path for signature checks.
 
 
 OPTIONAL PARAMETERS
 -------------------
 arch
-   set this if you need to force and specific arch (ubuntu specific)
+   Set this if you need to force any specific CPU architectures.
    This parameter can be used multiple times.
+
+   Defaults to download all architectures defined by ``APT::Architectures``.
 component
    The component(s) to enable. Can be used multiple times.
 distribution
@@ -44,7 +46,7 @@ state
 BOOLEAN PARAMETERS
 ------------------
 include-src
-   include deb-src entries
+   Add ``deb-src`` entries.
 
 
 EXAMPLES
@@ -53,15 +55,16 @@ EXAMPLES
 .. code-block:: sh
 
    __apt_source rabbitmq \
+      --state present \
       --uri http://www.rabbitmq.com/debian/ \
       --distribution testing \
       --component main \
-      --include-src \
-      --state present
+      --include-src
 
    __apt_source canonical_partner \
+      --state present \
       --uri http://archive.canonical.com/ \
-      --component partner --state present
+      --component partner
 
    __apt_source goaccess \
       --uri http://deb.goaccess.io/ \
@@ -73,11 +76,13 @@ AUTHORS
 -------
 * Steven Armstrong <steven-cdist--@--armstrong.cc>
 * Daniel Fancsali <fancsali--@--gmail.com>
+* Dennis Camera <dennis.camera--@--riiengineering.ch>
 
 
 COPYING
 -------
-Copyright \(C) 2011-2018 Steven Armstrong.
+Copyright \(C) 2011-2018 Steven Armstrong, 2022 Daniel Fancsali,
+2022,2025 Dennis Camera.
 You can redistribute it and/or modify it under the terms of the GNU General
 Public License as published by the Free Software Foundation, either version 3 of
 the License, or (at your option) any later version.

--- a/type/__apt_source/man.rst
+++ b/type/__apt_source/man.rst
@@ -31,8 +31,9 @@ arch
 component
    space delimited list of components to enable. Defaults to an empty string.
 distribution
-   the distribution codename to use. Defaults to DISTRIB_CODENAME from
-   the targets /etc/lsb-release
+   The distribution codename to use.
+
+   Defaults to: auto-detected release codename of the target.
 state
    ``present`` or ``absent``
 

--- a/type/__apt_source/man.rst
+++ b/type/__apt_source/man.rst
@@ -8,8 +8,8 @@ cdist-type__apt_source - Manage apt sources
 
 DESCRIPTION
 -----------
-This cdist type allows you to manage apt sources. It invokes index update
-internally when needed so call of index updating type is not needed.
+This type allows you to manage APT sources. It invokes index update internally
+when needed so call of index updating type is not needed.
 
 
 REQUIRED PARAMETERS

--- a/type/__apt_source/man.rst
+++ b/type/__apt_source/man.rst
@@ -28,8 +28,9 @@ OPTIONAL PARAMETERS
 -------------------
 arch
    set this if you need to force and specific arch (ubuntu specific)
+   This parameter can be used multiple times.
 component
-   space delimited list of components to enable. Defaults to an empty string.
+   The component(s) to enable. Can be used multiple times.
 distribution
    The distribution codename to use.
 

--- a/type/__apt_source/manifest
+++ b/type/__apt_source/manifest
@@ -26,8 +26,44 @@ join_lines() {
 
 name=${__object_id:?}
 state_should=$(cat "${__object:?}/parameter/state")
-uri=$(cat "${__object:?}/parameter/uri")
 
+os=$(cat "${__global:?}/explorer/os")
+case ${os}
+in
+	(debian)
+		os_version=$(cat "${__global:?}/explorer/os_version")
+		case ${os_version%%[!0-9]*}
+		in
+			([0123])
+				supports_sources_list_d=false ;;
+			(*)
+				# Debian 4.0 and later
+				supports_sources_list_d=true ;;
+		esac
+		;;
+	(ubuntu)
+		os_version=$(cat "${__global:?}/explorer/os_version")
+		case ${os_version%%[!0-9]*}
+		in
+			([45])
+				supports_sources_list_d=false ;;
+			(*)
+				# Ubuntu 6.06 and later
+				supports_sources_list_d=true ;;
+		esac
+		;;
+	(devuan)
+		supports_sources_list_d=true
+		;;
+	(*)
+		: "${__type:?}"  # make shellcheck happy
+		printf 'Your operating system (%s) is currently not supported by this type (%s)\n' "${os}" "${__type##*/}" >&2
+		printf 'Please contribute an implementation for it if you can.\n' >&2
+		exit 1
+		;;
+esac
+
+uri=$(cat "${__object:?}/parameter/uri")
 if test -f "${__object:?}/parameter/distribution"
 then
 	distribution=$(cat "${__object:?}/parameter/distribution")
@@ -63,19 +99,37 @@ then
 	signed_by="signed-by=$(join_lines ',' "${__object:?}/parameter/signed-by")"
 fi
 
-# export variables for use in template
-export name
-export uri
-export distribution
-export component
-export forcedarch
-export signed_by
+source_defn=$(
+	# export variables for use in template
+	export name
+	export uri
+	export distribution
+	export component
+	export forcedarch
+	export signed_by
+	"${__type:?}/files/source.list.template")
 
-# generate file from template
-mkdir "${__object:?}/files"
-"${__type:?}/files/source.list.template" >"${__object:?}/files/source.list"
+if ${supports_sources_list_d?}
+then
+	: "${__type:?}"  # make shellcheck happy
 
-__file "/etc/apt/sources.list.d/${name}.list" \
-	--source "${__object:?}/files/source.list" \
-	--owner 0 --group 0 --mode 0644 \
-	--state "${state_should}"
+	__file "/etc/apt/sources.list.d/${name}.list" \
+		--state "${state_should}" \
+		--owner 0 --group 0 --mode 0644 \
+		--source - <<-EOF
+		# Managed by skonfig (${__type##*/}).
+		# Changes will be overwritten.
+		#
+
+		# ${name:?}
+		${source_defn-}
+		EOF
+else
+	# old version which does not support the sources.list.d directory
+	__block "/etc/apt/sources.list:${name}" \
+		--state "${state_should}" \
+		--file /etc/apt/sources.list \
+		--prefix "# skonfig: ${__object_name:?}" \
+		--suffix "#/skonfig: ${__object_name:?}" \
+		--text "${source_defn-}"
+fi

--- a/type/__apt_source/manifest
+++ b/type/__apt_source/manifest
@@ -19,6 +19,11 @@
 # along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
 #
 
+join_lines() {
+	# NOTE: this function should not be used on untrusted input.
+	sed -e ':a' -e '$!N' -e "s/\n/$1/" -e 'ta' "$2"
+}
+
 name=${__object_id:?}
 state=$(cat "${__object:?}/parameter/state")
 uri=$(cat "${__object:?}/parameter/uri")
@@ -45,17 +50,17 @@ else
 	exit 1
 fi
 
-component=$(cat "${__object:?}/parameter/component")
+component=$(join_lines ' ' "${__object:?}/parameter/component")
 
-if [ -f "${__object:?}/parameter/arch" ]
+if test -s "${__object:?}/parameter/arch"
 then
-	forcedarch="arch=$(cat "${__object:?}/parameter/arch")"
+	forcedarch="arch=$(join_lines , "${__object:?}/parameter/arch")"
 fi
 
-if [ -f "${__object:?}/parameter/signed-by" ]
+if test -s "${__object:?}/parameter/signed-by"
 then
-   # Take all '--signed-by' parameter values present on separate lines and join them with a comma
-   signed_by="signed-by=$(sed -e ':a' -e '$!N' -e 's/\n/,/' -e 'ta' "${__object:?}/parameter/signed-by")"
+	# Take all --signed-by values and join them with a comma.
+	signed_by="signed-by=$(join_lines ',' "${__object:?}/parameter/signed-by")"
 fi
 
 # export variables for use in template

--- a/type/__apt_source/manifest
+++ b/type/__apt_source/manifest
@@ -25,7 +25,7 @@ join_lines() {
 }
 
 name=${__object_id:?}
-state=$(cat "${__object:?}/parameter/state")
+state_should=$(cat "${__object:?}/parameter/state")
 uri=$(cat "${__object:?}/parameter/uri")
 
 if test -f "${__object:?}/parameter/distribution"
@@ -74,7 +74,8 @@ export signed_by
 # generate file from template
 mkdir "${__object:?}/files"
 "${__type:?}/files/source.list.template" >"${__object:?}/files/source.list"
+
 __file "/etc/apt/sources.list.d/${name}.list" \
-   --source "${__object:?}/files/source.list" \
-   --owner root --group root --mode 0644 \
-   --state "${state}"
+	--source "${__object:?}/files/source.list" \
+	--owner 0 --group 0 --mode 0644 \
+	--state "${state_should}"

--- a/type/__apt_source/manifest
+++ b/type/__apt_source/manifest
@@ -1,6 +1,7 @@
 #!/bin/sh -e
 #
 # 2011-2018 Steven Armstrong (steven-cdist at armstrong.cc)
+# 2025 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #
@@ -22,11 +23,26 @@ name=${__object_id:?}
 state=$(cat "${__object:?}/parameter/state")
 uri=$(cat "${__object:?}/parameter/uri")
 
-if [ -f "${__object:?}/parameter/distribution" ]
+if test -f "${__object:?}/parameter/distribution"
 then
-   distribution=$(cat "${__object:?}/parameter/distribution")
+	distribution=$(cat "${__object:?}/parameter/distribution")
+elif test -s "${__global:?}/explorer/lsb_codename"
+then
+	distribution=$(cat "${__global:?}/explorer/lsb_codename")
+elif test -s "${__global:?}/explorer/os_release"
+then
+	distribution=$(
+		awk -F= '
+		function unquote(s) {
+			return (s~/^".*"$/||s~/^'\''.*'\''$/) ? substr(s,2,length(s)-2) : s
+		}
+		$1 == "VERSION_CODENAME" {
+			print unquote(substr($0, index($0, "=") + 1))
+		}' "${__global:?}/explorer/os_release")
 else
-   distribution=$(cat "${__global:?}/explorer/lsb_codename")
+	echo 'Could not determine distribution value automatically.' >&2
+	echo 'Please use the --distribution parameter to specify it manually.' >&2
+	exit 1
 fi
 
 component=$(cat "${__object:?}/parameter/component")

--- a/type/__apt_source/parameter/optional
+++ b/type/__apt_source/parameter/optional
@@ -1,4 +1,2 @@
-state
 distribution
-component
-arch
+state

--- a/type/__apt_source/parameter/optional_multiple
+++ b/type/__apt_source/parameter/optional_multiple
@@ -1,1 +1,3 @@
+arch
+component
 signed-by


### PR DESCRIPTION
This type is currently broken due to a regression introduced by 1e61371.

This PR further replaces remaining occurrences of cdist, makes `--arch` and `--component` multiple parameters which is cleaner from a skonfig-user view, adds codename detection from `os-release(5)` instead of just "legacy" LSB and some linting, typo corrections.