### PR TITLE
Add basic support for Synology DSM

### DIFF
--- a/explorer/disks
+++ b/explorer/disks
@@ -67,7 +67,10 @@ in
         then
             # shellcheck disable=SC2012
             ls -1 /sys/block/ \
-            | awk -v ign_majors="$(echo "${ign_majors}" | tr ' ' '|')" '
+            | awk -v ign_majors="${ign_majors}" '
+                BEGIN {
+                    gsub(/ /, "|", ign_majors)
+                }
                 {
                   devfile = "/sys/block/" $0 "/dev"
                   getline devno < devfile

--- a/explorer/init
+++ b/explorer/init
@@ -39,6 +39,8 @@
 #    systemd, upstart, sysvinit, openrc, ???
 #  Devuan:
 #    sysvinit, sysvinit+openrc
+#  DSM:
+#    busybox-init+syno, upstart-syno, systemd
 #  Gentoo:
 #    sysvinit+openrc, openrc-init, systemd
 #  Haiku:
@@ -155,10 +157,14 @@ check_busybox_init() (
 	test -x "${busybox_path}" || return 1
 	grep -q 'BusyBox v[0-9]' "${busybox_path}" || return 1
 
-	# It is quite common to use Busybox init to stack other init systemd
+	# It is quite common to use BusyBox’s init to stack other service managers
 	# (like OpenRC) on top of it. So we check for that, too.
 	if stacked=$(check_openrc)
 	then
+		echo "busybox-init+${stacked}"
+	elif stacked=$(check_synoinit)
+	then
+		# Synology DSM < 5.0 uses BusyBox + synoservice(8)
 		echo "busybox-init+${stacked}"
 	else
 		echo busybox-init
@@ -229,6 +235,13 @@ check_smf() {
 	echo smf
 }
 
+check_synoinit() {
+	# synoservice(8)
+	test -x /usr/syno/sbin/synoservice || return 1
+
+	echo syno
+}
+
 check_systemd() {
 	# NOTE: sd_booted(3)
 	test -d /run/systemd/system/ || return 1
@@ -263,7 +276,12 @@ check_upstart() {
 	case $(initctl version)
 	in
 		(*'(upstart '*')')
-			if test -d /etc/init
+			if test -x /usr/syno/sbin/synoservice \
+				&& test -x /usr/syno/sbin/synoservicectl
+			then
+				# upstart-based Synology init system
+				echo upstart-syno
+			elif test -d /etc/init
 			then
 				# modern (DBus-based?) upstart >= 0.5
 				echo upstart
@@ -300,10 +318,10 @@ find_init_procfs() (
 		# /sbin/init (deleted)
 		# [root@fedora-12 ~]# ls -l /proc/1/exe
 		# lrwxrwxrwx. 1 root root 0 2020-01-30 23:00 /proc/1/exe -> /sbin/init (deleted)
-
 		init_exe=${init_exe% (deleted)}
-		test -x "${init_exe}" || return 1
 	fi
+
+	test -x "${init_exe}" || return 1
 
 	echo "${init_exe}"
 )
@@ -400,10 +418,11 @@ check_list() (
 )
 
 
-# BusyBox's versions of ps and pgrep do not support some options
+# BusyBox’s versions of ps and pgrep do not support some options
 # depending on which compile-time options have been used.
 
 find_init_pgrep() {
+	command -v pgrep >/dev/null 2>&1 || return 1
 	pgrep -P0 -fl 2>/dev/null | awk -F '[[:blank:]]' '$1 == 1 { print $2 }'
 }
 

--- a/explorer/os
+++ b/explorer/os
@@ -213,6 +213,14 @@ then
    exit 0
 fi
 
+if test -f /etc/synoinfo.conf && test -f /etc/VERSION
+then
+   # Synology DiskStation Manager
+   echo dsm
+   exit 0
+fi
+
+
 # Appliances
 
 if grep -q '^Check Point Gaia' /etc/cp-release 2>/dev/null

--- a/explorer/os_version
+++ b/explorer/os_version
@@ -139,6 +139,25 @@ in
 
       echo "${devuan_version}"
       ;;
+   (dsm)
+      # e.g. 4.1-2668, 6.2.3-25426 Update 3
+
+      # shellcheck source=/dev/null
+      . /etc/VERSION || exit 0
+
+      # productversion is available on DSM 5.2+ only.
+      # For older versions fall back to concatenation of majorversion and minorversion.
+      : "${productversion:=${majorversion:-0}${minorversion:+.${minorversion}}}"
+
+      # some versions define smallfixnumber=0, which would produce
+      # "Update 0" and makes no sense.
+      test $((smallfixnumber)) -gt 0 || smallfixnumber=
+
+      printf '%s%s%s\n' \
+         "${productversion}" \
+         "${buildnumber:+-${buildnumber}}" \
+         "${smallfixnumber:+ Update ${smallfixnumber}}"
+      ;;
    (fedora)
       sed -e 's/^Fedora\( Core\)* release \(.*\) (.*)$/\2/' /etc/fedora-release
       ;;

--- a/type/__cron/explorer/cron-allowed
+++ b/type/__cron/explorer/cron-allowed
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2022 Dennis Camera (dennis.camera at riiengineering.ch)
+# 2022,2025 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #
@@ -24,6 +24,11 @@ cron_ok() { echo true; exit 0; }
 cron_fail() { printf '%s\n' "$1" >&2; exit "$2"; }
 
 user=$(cat "${__object:?}/parameter/user")
+
+command -v crontab >/dev/null 2>&1 || {
+	echo 'Cannot find crontab(1). This type does not work without it.' >&2
+	exit 1
+}
 
 case $(uname -s)
 in

--- a/type/__cron/explorer/entry
+++ b/type/__cron/explorer/entry
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2022 Dennis Camera (dennis.camera at riiengineering.ch)
+# 2022,2025 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #
@@ -34,7 +34,15 @@ crontab_list() {
 }
 
 grep_suffix() {
-	awk -v suffix="$1" 'substr($0, length($0) - length(suffix) + 1) == suffix'
+	awk -v suffix="$1" '
+	# skip comment lines
+	/^[[:blank:]]*#/ { next }
+
+	{
+		if (substr($0, length($0) - length(suffix) + 1) == suffix) {
+			print
+		}
+	}'
 }
 
-crontab_list | grep -v '^[[:blank:]]*#' | grep_suffix " # ${name}"
+crontab_list | grep_suffix " # ${name}"

--- a/type/__hostname/gencode-remote
+++ b/type/__hostname/gencode-remote
@@ -67,7 +67,7 @@ in
             "&& hostnamectl set-hostname '${name_should}'" \
             "|| hostname '${name_should}'"
         ;;
-    (centos|fedora|redhat|scientific|oraclelinux|crux|freebsd|netbsd|openbsd|gentoo|void)
+    (centos|fedora|redhat|scientific|oraclelinux|crux|freebsd|netbsd|openbsd|gentoo|void|dsm)
         echo "hostname '${name_should}'"
         ;;
     (openwrt)

--- a/type/__hostname/manifest
+++ b/type/__hostname/manifest
@@ -104,6 +104,30 @@ in
             --key 'HOSTNAME' \
             --value "${name_should}"
         ;;
+    (dsm)
+        read -r os_version <"${__global:?}/explorer/os_version"
+        case ${os_version%%-*}
+        in
+            ([123]|[123].*|4.[12]|4.[12].*)
+                # before DSM 4.3
+                __file /etc/sysconfig/network \
+                    --state exists \
+                    --owner 0 --group 0 --mode 0644
+                require=__file/etc/sysconfig/network \
+                __key_value /etc/sysconfig/network:HOSTNAME \
+                    --file /etc/sysconfig/network \
+                    --delimiter '=' --exact_delimiter \
+                    --key 'HOSTNAME' \
+                    --value "${name_should}"
+                ;;
+            (*)
+                # DSM 4.3 and later
+                printf '%s\n' "${name_should}" | __file /etc/hostname \
+                    --owner 0 --group 0 --mode 0644 \
+                    --source -
+                ;;
+        esac
+        ;;
     (gentoo)
         # Only write to /etc/conf.d/hostname on OpenRC-based installations.
         # On systemd use hostnamectl(1) in gencode-remote.

--- a/type/__locale_system/manifest
+++ b/type/__locale_system/manifest
@@ -96,6 +96,11 @@ in
             locale_conf='/etc/sysconfig/i18n'
         fi
         ;;
+    (dsm)
+        locale_conf='/etc/profile'
+        quote_value=false
+        key_prefix='export '
+        ;;
     (fedora)
         read -r os_version <"${__global:?}/explorer/os_version"
         if version_ge "${os_version}" 18
@@ -168,7 +173,7 @@ in
         # NOTE: lang.csh (csh config) is ignored here.
         locale_conf='/etc/profile.d/lang.sh'
         locale_conf_mode=0755
-        key="export ${__object_id:?}"
+        key_prefix='export '
         ;;
     (suse)
         read -r os_version <"${__global:?}/explorer/os_version"
@@ -207,10 +212,10 @@ __file "${locale_conf}" \
     --mode "${locale_conf_mode:-0644}"
 
 require="__file${locale_conf}" \
-__key_value "${locale_conf}:${key#export }" \
-    --file "${locale_conf}" \
-    --key "${key}" \
-    --delimiter '=' --exact_delimiter \
+__key_value "${locale_conf}:${key}" \
     --state "${state_should}" \
+    --file "${locale_conf}" \
+    --key "${key_prefix-}${key}" \
+    --delimiter '=' --exact_delimiter \
     --value "${value:-$(catval "${__object:?}/parameter/value")}" \
     --onchange "${onchange_cmd-}"

--- a/type/__sysctl/manifest
+++ b/type/__sysctl/manifest
@@ -1,8 +1,12 @@
 #!/bin/sh -e
 #
 # 2014 Steven Armstrong (steven-cdist at armstrong.cc)
+# 2017 Ľubomír Kučera (lubomir.kucera.jr at gmail.com)
+# 2018 Kamila Součková (kamila at ksp.sk)
+# 2018 Darko Poljak (darko.poljak at gmail.com)
 # 2018 Takashi Yoshi (takashi at yoshi.email)
-# 2019 Nico Schottelius (nico-cdist at schottelius.org)
+# 2016,2017,2019 Nico Schottelius (nico-cdist at schottelius.org)
+# 2023,2025 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #
@@ -26,7 +30,7 @@ os=$(cat "${__global:?}/explorer/os")
 case ${os}
 in
    # Linux
-   (alpine|redhat|centos|almalinux|eurolinux|rocky|oraclelinux|ubuntu|debian|devuan|archlinux|coreos)
+   (alpine|redhat|centos|almalinux|eurolinux|rocky|oraclelinux|ubuntu|debian|devuan|archlinux|coreos|dsm)
       :
       ;;
    # BSD


### PR DESCRIPTION
Granted, it may seem to come at the [worst possible time](https://www.synology.com/en-eu/company/news/article/DACH_VL_plus/Synology%20is%20increasingly%20relying%20on%20its%20own%20ecosystem%20for%20upcoming%20Plus%20models).
This PR has been in the works for some time already and I think it would be a shame to throw it away just because of one bad press release.

So here it is: basic support for Synology DSM.

Users and groups have not been touched, yet, because they would require quite some changes in the existing code.
Since larger changes are also required for improved support of other operating systems like Mac OS X or AIX, it makes more sense to add DSM support then (if I still have the motivation).

Support for DSM < 6.0 is partial.
* DSM < 6.0 is missing the `command` command and requires a polyfill which maps calls to `which`.
* DSM < 5.0 is missing the `tr` command which is harder to polyfill and it's probably easier to try to replace `tr` with other commands in skonfig. Currently not implemented. To get the basics working at the very least the `machine_type` explorer would need to be updated.