### PR TITLE
Allow multiple `--onchange`

### DIFF
--- a/type/__clean_path/gencode-remote
+++ b/type/__clean_path/gencode-remote
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 #
 # 2024 Ander Punnar (ander at kvlt.ee)
-# 2024 Dennis Camera (dennis.camera at riiengineering.ch)
+# 2024-2025 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #
@@ -27,9 +27,7 @@ echo '${__type:?}/explorer/find -depth -exec rm -rf {} +'
 
 ln -sf "${found}" "${__messages_out:?}"
 
-onchange="${__object:?}/parameter/onchange"
-
-if [ -f "${onchange}" ]
+if test -s "${__object:?}/parameter/onchange"
 then
-    cat "${onchange}"
+    cat "${__object:?}/parameter/onchange"
 fi

--- a/type/__clean_path/man.rst
+++ b/type/__clean_path/man.rst
@@ -20,9 +20,14 @@ This type is mostly POSIX compatible.
 OPTIONAL PARAMETERS
 -------------------
 path
-   Path to be cleaned. Defaults to ``$__object_id``.
+   Path to be cleaned.
+
+   Defaults to: ``__object_id``
 onchange
-   The code to run if something was removed.
+   Execute the given command if something was removed.
+
+   Can be used multiple times to execute multiple commands.
+   The commands will be executed in the order the parameters are specified.
 
 
 OPTIONAL MULTIPLE PARAMETERS

--- a/type/__clean_path/parameter/optional
+++ b/type/__clean_path/parameter/optional
@@ -1,4 +1,3 @@
 exclude
-onchange
 path
 pattern

--- a/type/__clean_path/parameter/optional_multiple
+++ b/type/__clean_path/parameter/optional_multiple
@@ -7,6 +7,7 @@ not-newer
 not-path
 not-regex
 not-type
+onchange
 rm-atime
 rm-ctime
 rm-iname

--- a/type/__debconf_set_selections/gencode-remote
+++ b/type/__debconf_set_selections/gencode-remote
@@ -61,7 +61,7 @@ then
 		  done
 	fi
 
-	if test -f "${__object:?}/parameter/onchange"
+	if test -s "${__object:?}/parameter/onchange"
 	then
 		cat "${__object:?}/parameter/onchange"
 	fi

--- a/type/__debconf_set_selections/man.rst
+++ b/type/__debconf_set_selections/man.rst
@@ -27,7 +27,10 @@ line
    (This parameter is actually required, but marked optional because the
    deprecated ``--file`` is still accepted.)
 onchange
-   Run command after change. Runs after ``--reconfigure``.
+   Execute the given command after change. Runs after ``--reconfigure``.
+
+   Can be used multiple times to execute multiple commands.
+   The commands will be executed in the order the parameters are specified.
 
 
 BOOLEAN PARAMETERS

--- a/type/__debconf_set_selections/parameter/optional
+++ b/type/__debconf_set_selections/parameter/optional
@@ -1,2 +1,1 @@
 file
-onchange

--- a/type/__debconf_set_selections/parameter/optional_multiple
+++ b/type/__debconf_set_selections/parameter/optional_multiple
@@ -1,1 +1,2 @@
 line
+onchange

--- a/type/__download/gencode-remote
+++ b/type/__download/gencode-remote
@@ -43,7 +43,7 @@ gencode_cksum "${download_tmp_q}"
 printf 'mv %s %s\n' "${download_tmp_q}" "$(shquot "${remote_dst:?}")"
 
 # execute --onchange (both for local and remote download)
-if test -f "${__object:?}/parameter/onchange"
+if test -s "${__object:?}/parameter/onchange"
 then
 	cat "${__object:?}/parameter/onchange"
 fi

--- a/type/__download/man.rst
+++ b/type/__download/man.rst
@@ -49,7 +49,10 @@ download
    For local downloads it is expected that usable utilities for downloading
    exist in the system. Type will try to use ``curl``, ``fetch`` or ``wget``.
 onchange
-   Execute this command after download.
+   Execute the given command after downloading.
+
+   Can be used multiple times to execute multiple commands.
+   The commands will be executed in the order the parameters are specified.
 sum
    Supported formats: ``cksum`` output without file name, MD5, SHA1 and SHA256.
 

--- a/type/__download/parameter/optional
+++ b/type/__download/parameter/optional
@@ -2,5 +2,4 @@ cmd-get
 cmd-sum
 destination
 download
-onchange
 sum

--- a/type/__download/parameter/optional_multiple
+++ b/type/__download/parameter/optional_multiple
@@ -1,2 +1,1 @@
 onchange
-option

--- a/type/__file/gencode-remote
+++ b/type/__file/gencode-remote
@@ -155,7 +155,7 @@ in
 		;;
 esac
 
-if ${fire_onchange?} && test -f "${__object:?}/parameter/onchange"
+if ${fire_onchange?} && test -s "${__object:?}/parameter/onchange"
 then
 	cat "${__object:?}/parameter/onchange"
 fi

--- a/type/__file/man.rst
+++ b/type/__file/man.rst
@@ -41,7 +41,11 @@ mode
 
    Defaults to: ``0600``
 onchange
-   The code to run if file is modified.
+   Execute the given command after the file was modified (if it had to be
+   modified).
+
+   Can be used multiple times to execute multiple commands.
+   The commands will be executed in the order the parameters are specified.
 owner
    User to :strong:`chown`\ (1) to.
 

--- a/type/__file/parameter/optional
+++ b/type/__file/parameter/optional
@@ -1,6 +1,5 @@
-state
 group
 mode
 owner
 source
-onchange
+state

--- a/type/__file/parameter/optional_multiple
+++ b/type/__file/parameter/optional_multiple
@@ -1,2 +1,1 @@
 onchange
-option

--- a/type/__key_value/gencode-remote
+++ b/type/__key_value/gencode-remote
@@ -83,7 +83,7 @@ esac
 
 cat "${__type:?}/files/remote_script.sh"
 
-if ${fire_onchange?}
+if ${fire_onchange?} && test -s "${__object:?}/parameter/onchange"
 then
     cat "${__object:?}/parameter/onchange"
 fi

--- a/type/__key_value/man.rst
+++ b/type/__key_value/man.rst
@@ -30,8 +30,11 @@ comment
 key
    The key to change. Defaults to object_id.
 onchange
-   The code to run if the key or value changes (i.e. is inserted, removed or
-   replaced).
+   Execute the given command if the key or value was changed (i.e. was inserted,
+   removed, or replaced).
+
+   Can be used multiple times to execute multiple commands.
+   The commands will be executed in the order the parameters are specified.
 state
    present or absent, defaults to present. If present, sets the key to value,
    if absent, removes the key from the file.

--- a/type/__key_value/parameter/optional
+++ b/type/__key_value/parameter/optional
@@ -1,5 +1,4 @@
-key
-value
-state
 comment
-onchange
+key
+state
+value

--- a/type/__key_value/parameter/optional_multiple
+++ b/type/__key_value/parameter/optional_multiple
@@ -1,2 +1,1 @@
 onchange
-option

--- a/type/__line/gencode-remote
+++ b/type/__line/gencode-remote
@@ -146,7 +146,7 @@ END {
 mv -f "\${tmpfile}" "${file}"
 DONE
 
-if [ -f "${__object:?}/parameter/onchange" ]
+if test -s "${__object:?}/parameter/onchange"
 then
    cat "${__object:?}/parameter/onchange"
 fi

--- a/type/__line/man.rst
+++ b/type/__line/man.rst
@@ -26,7 +26,10 @@ line
    Must be set, if ``--state present`` or ``--state replace``.
    Ignored if ``--regex`` is used and ``--state absent``.
 onchange
-   The code to run if line is added, removed or updated.
+   Execute the given command after a line was added, removed, or updated.
+
+   Can be used multiple times to execute multiple commands.
+   The commands will be executed in the order the parameters are specified.
 regex
    If ``--state present``, search for this pattern and if it matches add
    the given line.

--- a/type/__line/parameter/optional
+++ b/type/__line/parameter/optional
@@ -4,4 +4,3 @@ file
 line
 regex
 state
-onchange

--- a/type/__line/parameter/optional_multiple
+++ b/type/__line/parameter/optional_multiple
@@ -1,2 +1,1 @@
 onchange
-option

--- a/type/__rsync/gencode-local
+++ b/type/__rsync/gencode-local
@@ -148,7 +148,7 @@ printf 'rsync%s %s %s@%s:%s\n' \
     "$(shquot "${__target_host:?}")" \
     "$(shquot "${dst}")"
 
-if [ -f "${__object:?}/parameter/onchange" ]
+if test -s "${__object:?}/parameter/onchange"
 then
     cat "${__object:?}/parameter/onchange"
 fi

--- a/type/__rsync/man.rst
+++ b/type/__rsync/man.rst
@@ -53,7 +53,10 @@ mode
    Requires rsync >= 2.6.7; numeric modes (e.g. `--chmod=644,D755`) require
    rsync >= 3.1.0.
 onchange
-   Command to run in target after sync.
+   Execute the given command on the target after rsync is complete.
+
+   Can be used multiple times to execute multiple commands.
+   The commands will be executed in the order the parameters are specified.
 options
    Due to a `bug in Python's argparse<https://bugs.python.org/issue9334>`_,
    the value must be prefixed with ``\``.

--- a/type/__rsync/parameter/optional
+++ b/type/__rsync/parameter/optional
@@ -4,4 +4,3 @@ mode
 options
 owner
 remote-user
-onchange

--- a/type/__sed/gencode-remote
+++ b/type/__sed/gencode-remote
@@ -68,7 +68,7 @@ echo 'rm -f "${tmp}"'
 
 echo 'change' >>"${__messages_out:?}"
 
-if [ -f "${__object:?}/parameter/onchange" ]
+if test -s "${__object:?}/parameter/onchange"
 then
     cat "${__object:?}/parameter/onchange"
 fi

--- a/type/__sed/man.rst
+++ b/type/__sed/man.rst
@@ -3,12 +3,12 @@ cdist-type__sed(7)
 
 NAME
 ----
-cdist-type__sed - Transform text files with ``sed``
+cdist-type__sed - Transform text files with :strong:`sed`\ (1)
 
 
 DESCRIPTION
 -----------
-Transform text files with ``sed``.
+Transform text files with :strong:`sed`\ (1).
 
 
 REQUIRED MULTIPLE PARAMETERS
@@ -21,9 +21,14 @@ script
 OPTIONAL PARAMETERS
 -------------------
 file
-   Path to the file. Defaults to ``$__object_id``.
+   Path to the file.
+
+   Defaults to: ``$__object_id``
 onchange
-   Execute this command if ``sed`` changes file.
+   Execute the given command after :strong:`sed`\ (1) changed the file.
+
+   Can be used multiple times to execute multiple commands.
+   The commands will be executed in the order the parameters are specified.
 
 
 BOOLEAN PARAMETERS

--- a/type/__sed/parameter/optional
+++ b/type/__sed/parameter/optional
@@ -1,2 +1,1 @@
 file
-onchange

--- a/type/__sed/parameter/optional_multiple
+++ b/type/__sed/parameter/optional_multiple
@@ -1,2 +1,1 @@
 onchange
-option

--- a/type/__unpack/gencode-remote
+++ b/type/__unpack/gencode-remote
@@ -109,7 +109,7 @@ then
     printf 'removed archive %s\n' "${src}" >>"${__messages_out:?}"
 fi
 
-if [ -f "${__object:?}/parameter/onchange" ]
+if test -s "${__object:?}/parameter/onchange"
 then
     cat "${__object:?}/parameter/onchange"
 fi

--- a/type/__unpack/man.rst
+++ b/type/__unpack/man.rst
@@ -45,7 +45,10 @@ backup-destination
    ``XXX.cdist__unpack_backup_YYY``, where ``XXX`` is destination and
    ``YYY`` current UNIX timestamp.
 onchange
-   Execute this command after unpack.
+   Execute the given command after unpacking.
+
+   Can be used multiple times to execute multiple commands.
+   The commands will be executed in the order the parameters are specified.
 preserve-archive
    Don't delete archive after unpacking.
 

--- a/type/__unpack/parameter/optional
+++ b/type/__unpack/parameter/optional
@@ -1,4 +1,3 @@
 sum-file
-tar-strip
 tar-extra-args
-onchange
+tar-strip

--- a/type/__unpack/parameter/optional_multiple
+++ b/type/__unpack/parameter/optional_multiple
@@ -1,2 +1,1 @@
 onchange
-option


### PR DESCRIPTION
This PR converts all `--onchange` parameters to `optional_multiple`.
Sometimes it may be useful to run multiple commands on change.

While it is possible to pass any amount of shell code to `--onchange` it's not very "convenient" when code grows larger than one line.
In spirit of various standard shell utilities which accept multiple `-e` options (e.g. `sed`, `grep`) I think it makes sense to convert the `--onchange` parameter to `optional_multiple`.

skonfig will concatenate all values using line feeds so no further code is needed to implement this feature.

I changed the `if`s to use `test -s` over `test -f`. While `test -f` works I prefer `test -s` to not `cat` empty files.