### PR TITLE
__rsync: Run `--onchange` on the target

### DIFF
--- a/type/__rsync/gencode-local
+++ b/type/__rsync/gencode-local
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 #
 # 2021,2023 Ander Punnar (ander at kvlt.ee)
-# 2023-2024 Dennis Camera (dennis.camera at riiengineering.ch)
+# 2023-2025 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-base.
 #
@@ -147,10 +147,5 @@ printf 'rsync%s %s %s@%s:%s\n' \
     "$(shquot "${remote_user}")" \
     "$(shquot "${__target_host:?}")" \
     "$(shquot "${dst}")"
-
-if test -s "${__object:?}/parameter/onchange"
-then
-    cat "${__object:?}/parameter/onchange"
-fi
 
 echo 'synced' >>"${__messages_out:?}"

--- a/type/__rsync/gencode-remote
+++ b/type/__rsync/gencode-remote
@@ -1,0 +1,26 @@
+#!/bin/sh -e
+#
+# 2025 Dennis Camera (dennis.camera at riiengineering.ch)
+#
+# This file is part of skonfig-base.
+#
+# skonfig-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-base. If not, see <http://www.gnu.org/licenses/>.
+#
+
+# only run --onchange if gencode-local emitted a "synced" message
+if test -s "${__object:?}/parameter/onchange" \
+    && grep -qxF -e "${__object_name:?}:synced" "${__messages_in:?}"
+then
+    cat "${__object:?}/parameter/onchange"
+fi

--- a/type/__rsync/man.rst
+++ b/type/__rsync/man.rst
@@ -105,7 +105,7 @@ AUTHORS
 
 COPYING
 -------
-Copyright \(C) 2021 Ander Punnar, 2023-2024 Dennis Camera.
+Copyright \(C) 2021 Ander Punnar, 2023-2025 Dennis Camera.
 You can redistribute it and/or modify it under the terms of the GNU General
 Public License as published by the Free Software Foundation, either version 3 of
 the License, or (at your option) any later version.


### PR DESCRIPTION
Unlike documented in [man.rst](https://github.com/skonfig/base/blob/07840f61914adf7fbc1eac599ec7691efbd26874/type/__rsync/man.rst?plain=1#L55), the `--onchange` commands were actually run on the config host.

This commit fixes this by moving this part of the code from `gencode-local` to `gencode-remote`.
To detect if `code-local` actually performed a sync `gencode-remote` checks for the "synced" message emitted by `gencode-local`.

Example:
```console
$ mkdir /tmp/xyz
$ (cd /tmp/xyz && touch foo bar baz)
$ echo '__rsync /tmp/rsynctest --source /tmp/xyz --onchange "echo synced >/tmp/foo" | skonfig -i- openbsd-77.vm
INFO: openbsd-77.vm: Starting configuration run
INFO: openbsd-77.vm: Processing __packge_pkg_openbsd/rsync
INFO: openbsd-77.vm: Processing __rsync/tmp/rsynctest
INFO: openbsd-77.vm: Finished successful run in 8.42 seconds
$ ssh openbsd-77.vm 'cat /tmp/foo'
cat: /tmp/foo: No such file or directory
$ cat /tmp/foo
synced
```