### PR TITLE
__package: Use apk for Adélie Linux

### DIFF
--- a/type/__package/manifest
+++ b/type/__package/manifest
@@ -48,7 +48,7 @@ else
       (suse) type='zypper' ;;
       (openwrt) type='opkg' ;;
       (openbsd) type='pkg_openbsd' ;;
-      (alpine|chimera) type='apk' ;;
+      (adelie|alpine|chimera) type='apk' ;;
       (*)
          printf "Don't know how to manage packages on: %s\\n" "${os}" >&2
          exit 1


### PR DESCRIPTION
Adélie Linux uses the apk package manager to install software packages.