### PR TITLE
[__locale_system] ubuntu 23.10+ uses /etc/locale.conf

### DIFF
--- a/type/__locale_system/manifest
+++ b/type/__locale_system/manifest
@@ -72,7 +72,11 @@ in
         ;;
     (ubuntu)
         os_version=$(cat "${__global:?}/explorer/os_version")
-        if version_ge "${os_version}" 6.10
+        if version_ge "${os_version}" 23.10
+        then
+            # Ubuntu 23.10 (mantic) and later
+            locale_conf='/etc/locale.conf'
+        elif version_ge "${os_version}" 6.10
         then
             # Ubuntu 6.10 (edgy) and later
             locale_conf='/etc/default/locale'


### PR DESCRIPTION
Fresh images.

22.04 (Jammy):
```
root@test-jammy:~# stat /etc/default/locale | head -1
  File: /etc/default/locale
```

24.04 (Noble):
```
root@test-noble:~# stat /etc/default/locale | head -1
  File: /etc/default/locale -> ../locale.conf
```

Sometime between 22.04 and 24.04 they pulled in change from Debian testing (Trixie).

Maybe some other release in between these two had that sooner, but I'm too lazy to check.