### PR TITLE
__group: Fix not all arguments passed to utilities

### DIFF
--- a/type/__group/gencode-remote/init
+++ b/type/__group/gencode-remote/init
@@ -39,6 +39,9 @@ quote_ifneeded() {
 		fi
 	done
 	unset -v _arg
+
+	# NOTE: Use printf because POSIX echo interprets escape sequences
+	printf '%s' "$*"
 }
 
 case ${os}


### PR DESCRIPTION
`quote_ifneeded()` did not print its result, so all arguments which could require quoting weren't passed to the OS utilities (`groupadd` & co.)