### PR TITLE
explorer/{cpu_cores,cpu_sockets,memory}: Misc. fixes for NetBSD

### DIFF
--- a/explorer/cpu_cores
+++ b/explorer/cpu_cores
@@ -35,11 +35,12 @@ in
     (macosx)
         sysctl -n hw.physicalcpu
         ;;
-    (openbsd)
-        sysctl -n hw.ncpuonline
+    (netbsd|openbsd)
+        # OpenBSD sysctl(8) always exits 0 (thus `grep .' to check for success)
+        /sbin/sysctl -n hw.ncpuonline 2>/dev/null | grep . \
+        || /sbin/sysctl -n hw.ncpu
         ;;
-    (freebsd|netbsd)
-        PATH=$(getconf PATH)
+    (freebsd)
         sysctl -n hw.ncpu
         ;;
     (*)

--- a/explorer/cpu_cores
+++ b/explorer/cpu_cores
@@ -45,8 +45,9 @@ in
     (*)
         if test -r /proc/cpuinfo
         then
-            cores=$(grep -c -e '^processor[[:blank:]]*:' /proc/cpuinfo)
-            test $((cores)) -ge 1 && echo $((cores)) || echo 1
+            cores=$(grep -c -e '^processor[[:blank:]]*:' /proc/cpuinfo || :)
+            test $((cores)) -gt 0 || cores=1
+            printf '%u\n' "${cores}"
         fi
         ;;
 esac

--- a/explorer/cpu_sockets
+++ b/explorer/cpu_sockets
@@ -28,15 +28,14 @@ in
     (macosx)
         system_profiler SPHardwareDataType | grep -F 'Number of Processors' | awk -F': ' '{print $2}'
         ;;
+    (netbsd)
+        ;;
     (*)
         if test -r /proc/cpuinfo
         then
             sockets=$(grep -e '^physical id[[:blank:]]*:' /proc/cpuinfo | sort -u | wc -l)
-            if test $((sockets)) -lt 1
-            then
-                sockets=$(grep -c -e '^processor[[:blank:]]*:' /proc/cpuinfo)
-            fi
-            echo $((sockets))
+            test $((sockets)) -gt 0 || sockets=1
+            printf '%u\n' "${sockets}"
         fi
         ;;
 esac

--- a/explorer/memory
+++ b/explorer/memory
@@ -89,10 +89,12 @@ in
 		then
 			# Use memory blocks if the architecture (e.g. x86, PPC64, s390)
 			# supports them (they denote physical memory)
-			num_mem_blocks=$(cat /sys/devices/system/memory/memory[0-9]*/state | grep -cxF online)
-			mem_block_size=$(cat /sys/devices/system/memory/block_size_bytes)
-
-			echo $((num_mem_blocks * 0x${mem_block_size})) | bytes2kib && exit
+			if num_mem_blocks=$(cat /sys/devices/system/memory/memory[0-9]*/state 2>/dev/null | grep -cxF online)
+			then
+				mem_block_size=$(cat /sys/devices/system/memory/block_size_bytes)
+				echo $((num_mem_blocks * 0x${mem_block_size})) | bytes2kib
+				exit 0
+			fi
 		fi
 		if test -r /proc/meminfo
 		then

--- a/explorer/memory
+++ b/explorer/memory
@@ -62,9 +62,17 @@ in
 	(FreeBSD)
 		sysctl -n hw.realmem | bytes2kib
 		;;
-	(NetBSD|OpenBSD)
-		# NOTE: This reports "usable" memory, not physically installed memory.
-		command -p sysctl -n hw.physmem | bytes2kib
+	(NetBSD)
+		# NOTE: This reports "usable" memory, not physically installed memory
+		#       (on some architectures).
+		#
+		#       hw.physmem64 is available on NetBSD >= 2.0
+		/sbin/sysctl -n hw.physmem64 | bytes2kib
+		;;
+	(OpenBSD)
+		# NOTE: This reports "usable" memory, not physically installed memory
+		#       (on some architectures).
+		sysctl -n hw.physmem | bytes2kib
 		;;
 	(SunOS)
 		# Make sure that awk from xpg4 is used for the scripts to work


### PR DESCRIPTION
`explorer/{cpu_cores,cpu_sockets}`:

Assume that multiple processors are cores instead of sockets.
For most architectures sockets are not reported using "physical id" in `/proc/cpuinfo`, making this explorer report all cores as separate sockets.
This does not make much sense. For most systems assuming one socket and N cores seems to be more correct to me.

On NetBSD `/proc/cpuinfo` is only implemented for a few architectures.
For all the others `/proc/cpuinfo` is an empty file (which makes `grep -c` exit 1).

On NetBSD also currently no architecture reports "physical id", so socket detection using `/proc/cpuinfo` will never work.
It is thus disabled on NetBSD until somebody finds another way.

NetBSD also has `hw.ncpuonline` like OpenBSD (in fact, OpenBSD imported the code for it from NetBSD).
So it makes more sense to merge the code for NetBSD and OpenBSD instead of NetBSD and FreeBSD.

`explorer/memory`:

OpenBSD exports `HW_PHYSMEM64` as `hw.physmem`.
NetBSD exports `HW_PHYSMEM` as `hw.physmem` and `HW_PHYSMEM64` as `hw.physmem64` (since NetBSD 2.0).

NetBSD < 2.0 is not supported by this code. For these versions `hw.physmem` could be used as a fall back, but I haven't implemented it because there are numerous other problems with its outdated `/bin/sh` (switching to `/bin/ksh` would fix those, though).

In the unlikely (or impossible?) case that there are no online memory blocks, fall back to `/proc/meminfo`. (`grep -c` problem cf. above).
