### PR TITLE
__cron: Remove deprecated parameters

### DIFF
--- a/type/__cron/gencode-remote
+++ b/type/__cron/gencode-remote
@@ -35,31 +35,15 @@ name=${__object_name:?}
 user=$(cat "${__object:?}/parameter/user")
 command=$(cat "${__object:?}/parameter/command")
 
-if test -f "${__object:?}/parameter/raw_command"
-then
-	echo 'error: parameter --raw_command is not supported anymore.' >&2
-	exit 1
-elif test -f "${__object:?}/parameter/raw"
+if test -f "${__object:?}/parameter/raw"
 then
 	read -r when <"${__object:?}/parameter/raw"
 else
 	read -r minute <"${__object:?}/parameter/minute"
 	read -r hour <"${__object:?}/parameter/hour"
-	if test -f "${__object:?}/parameter/day_of_month"
-	then
-		# deprecated name
-		read -r day_of_month <"${__object:?}/parameter/day_of_month"
-	else
-		read -r day_of_month <"${__object:?}/parameter/day-of-month"
-	fi
+	read -r day_of_month <"${__object:?}/parameter/day-of-month"
 	read -r month <"${__object:?}/parameter/month"
-	if test -f "${__object:?}/parameter/day_of_week"
-	then
-		# deprecated name
-		read -r day_of_week <"${__object:?}/parameter/day_of_week"
-	else
-		read -r day_of_week <"${__object:?}/parameter/day-of-week"
-	fi
+	read -r day_of_week <"${__object:?}/parameter/day-of-week"
 	when="${minute} ${hour} ${day_of_month} ${month} ${day_of_week}"
 fi
 

--- a/type/__cron/parameter/boolean
+++ b/type/__cron/parameter/boolean
@@ -1,1 +1,0 @@
-raw_command

--- a/type/__cron/parameter/deprecated/day_of_month
+++ b/type/__cron/parameter/deprecated/day_of_month
@@ -1,1 +1,0 @@
-use --day-of-week instead

--- a/type/__cron/parameter/deprecated/day_of_week
+++ b/type/__cron/parameter/deprecated/day_of_week
@@ -1,1 +1,0 @@
-use --day-of-week instead

--- a/type/__cron/parameter/deprecated/raw_command
+++ b/type/__cron/parameter/deprecated/raw_command
@@ -1,1 +1,0 @@
-use cdist-type__cron_env(7) instead

--- a/type/__cron/parameter/optional
+++ b/type/__cron/parameter/optional
@@ -1,9 +1,7 @@
 state
 minute
 hour
-day_of_month
 day-of-month
 month
-day_of_week
 day-of-week
 raw


### PR DESCRIPTION
The `--raw_command`, `--day_of_month`, `--day_of_week` have been deprecated for more than three years.