### PR TITLE
__start_on_boot: Speed up state explorer on OpenBSD

### DIFF
--- a/type/__start_on_boot/explorer/state
+++ b/type/__start_on_boot/explorer/state
@@ -155,13 +155,17 @@ else
             esac
             ;;
         (openbsd)
-            state='absent'
             # OpenBSD 5.7 and higher
-            rcctl ls on | grep "^${name}$" && state='present'
+            if rcctl get "${name}" status >/dev/null
+            then
+                state='present'
+            else
+                state='absent'
+            fi
             ;;
 
         (*)
-            printf 'Unsupported os: %s\n' "${os}" >&2
+            printf 'Unsupported OS: %s\n' "${os}" >&2
             exit 1
             ;;
     esac


### PR DESCRIPTION
Instead of running `rcctl ls on` and grep(1)ing for the service of interest, we can just query the service's status.  `rcctl ls on` does the same thing, but it queries the status for all services which is unnecessary for this case.

Further, the grep(1) (which interpreted the service name as a regular expression) is not necessary anymore.  Another issue with the grep was that it printed the service name if it matched, breaking `$state_is` in `manifest` and `gencode-remote`.